### PR TITLE
fix(client): skip body if method is `head`

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -217,10 +217,13 @@ class Client extends EventEmitter {
       // TODO move this[kCallbacks] from being an array. The array allocation
       // is showing up in the flamegraph.
       const cb = this[kCallbacks].shift()
-      this._needHeaders--
-      this._lastBody = new Readable({ read: this[kRead].bind(this) })
-      this._lastBody.push = this[kRequests].shift().wrapSimple(this._lastBody, this._lastBody.push)
+      const request = this[kRequests].shift()
+      const skipBody = request.method === 'HEAD'
 
+      if (!skipBody) {
+        this._lastBody = new Readable({ read: this[kRead].bind(this) })
+        this._lastBody.push = request.wrapSimple(this._lastBody, this._lastBody.push)
+      }
       cb(null, {
         statusCode,
         headers: parseHeaders(headers),
@@ -230,6 +233,8 @@ class Client extends EventEmitter {
       if (this.closed && this[kQueue].length() === 0) {
         this.destroy()
       }
+
+      return skipBody
     }
 
     this.parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
@@ -239,7 +244,9 @@ class Client extends EventEmitter {
     this.parser[HTTPParser.kOnMessageComplete] = () => {
       const body = this._lastBody
       this._lastBody = null
-      body.push(null)
+      if (body !== null) {
+        body.push(null)
+      }
     }
 
     this[kReadCb] = () => {


### PR DESCRIPTION
In case of HEAD method `client.parser.[HTTPParser.kOnHeadersComplete]`
should tell the parser to skip the body by returning 2.

See https://github.com/creationix/http-parser-js/blob/master/http-parser.js#L357

I ran tests multiple times and on my machine the `lib/pool.js` tests failed once in the git precommit hook. 

I'll look into adding tests also.