### PR TITLE
Pass callback directly to connect, reconnect

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ const kRequests = Symbol('requests')
 const kTimer = Symbol('kTimer')
 const kTLSOpts = Symbol('TLS Options')
 
-function connect (client) {
+function connect (client, rawCb) {
   var socket = null
   var url = client.url
   // the defaults port are needed because of the URL spec
@@ -53,10 +53,12 @@ function connect (client) {
     reconnect(client, new Error('this side closed - finished'))
   })
 
-  socket.on('error', reconnect.bind(undefined, client))
+  socket.on('error', (err) => {
+    reconnect(client, err, rawCb)
+  })
 }
 
-function reconnect (client, err) {
+function reconnect (client, err, rawCb) {
   if (client.closed) {
     // TODO what do we do with the error?
     return
@@ -77,6 +79,8 @@ function reconnect (client, err) {
   if (client[kQueue].length() > 0) {
     connect(client)
   }
+
+  if (!callbacks.length && rawCb) return rawCb(err, null)
 
   for (const cb of callbacks) {
     cb(err, null)
@@ -305,7 +309,7 @@ class Client extends EventEmitter {
     }
 
     if (!this.socket) {
-      connect(this)
+      connect(this, cb)
     }
 
     try {

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -235,3 +235,18 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
     })
   })
 })
+
+test('ECONNREFUSED on initial connection executes error callback', (t) => {
+  t.plan(3)
+
+  const client = new Client('http://localhost:12345', {
+    pipelining: 1
+  })
+  t.tearDown(client.close.bind(client))
+
+  client.request({ path: '/', method: 'GET' }, (err, data) => {
+    t.ok(err instanceof Error) // we are expecting an error
+    t.strictEqual(err.code, 'ECONNREFUSED')
+    t.strictEqual(null, data)
+  })
+})


### PR DESCRIPTION
This is to ensure that initial socket connection errors are caught.
Alternatively, we could push the callback into the queue before calling
`connect`. However, that has potential side-effects. I went for the
solution with the least chance of unintended consequences.