### PR TITLE
fix: validate URL

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -91,6 +91,14 @@ class Client extends EventEmitter {
       url = new URL(url)
     }
 
+    if (!/https?/.test(url.protocol)) {
+      throw new Error('invalid url')
+    }
+
+    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+      throw new Error('invalid url')
+    }
+
     this.url = url
 
     // state machine, might need more states

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -235,3 +235,31 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
     })
   })
 })
+
+test('invalid URL throws', (t) => {
+  t.plan(4)
+
+  try {
+    new Client(new URL('asd://asd')) // eslint-disable-line
+  } catch (err) {
+    t.strictEqual(err.message, 'invalid url')
+  }
+
+  try {
+    new Client(new URL('http://asd:200/somepath')) // eslint-disable-line
+  } catch (err) {
+    t.strictEqual(err.message, 'invalid url')
+  }
+
+  try {
+    new Client(new URL('http://asd:200?q=asd')) // eslint-disable-line
+  } catch (err) {
+    t.strictEqual(err.message, 'invalid url')
+  }
+
+  try {
+    new Client(new URL('http://asd:200#asd')) // eslint-disable-line
+  } catch (err) {
+    t.strictEqual(err.message, 'invalid url')
+  }
+})


### PR DESCRIPTION
The client constructor only expects, protocol, host and port.
Anything else will be ignored. Throw in order to inform user
of incorrect usage, e.g. a user might assume that the path
is always prepended to all requests.