### PR TITLE
refactor: extract reset parser

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -21,7 +21,6 @@ const kTimer = Symbol('timer')
 const kTLSOpts = Symbol('TLS Options')
 const kLastBody = Symbol('lastBody')
 const kNeedHeaders = Symbol('needHeaders')
-const kResetParser = Symbol('resetParser')
 const kStream = Symbol('kStream')
 
 function connect (client) {
@@ -35,8 +34,6 @@ function connect (client) {
   }
 
   client.socket = socket
-
-  client[kResetParser]()
 
   // stop the queue and reset the parsing state
   client[kQueue].pause()
@@ -74,7 +71,7 @@ function reconnect (client, err) {
     return
   }
 
-  client[kResetParser]()
+  resetParser(client)
 
   // reset events
   client.socket.removeAllListeners('end')
@@ -247,46 +244,7 @@ class Client extends EventEmitter {
       }
     }
 
-    this[kResetParser] = () => {
-      this.parser = new HTTPParser(HTTPParser.RESPONSE)
-      this.parser[HTTPParser.kOnHeaders] = () => {}
-      this.parser[HTTPParser.kOnHeadersComplete] = ({ statusCode, headers }) => {
-        // TODO move this[kInflight] from being an array. The array allocation
-        // is showing up in the flamegraph.
-        const { request, callback } = this[kInflight].shift()
-        const skipBody = request.method === 'HEAD'
-
-        if (!skipBody) {
-          this[kLastBody] = new this[kStream].Readable({ read: this[kRead] })
-          this[kLastBody].push = request.wrapSimple(this[kLastBody], this[kLastBody].push)
-        }
-        callback(null, {
-          statusCode,
-          headers: parseHeaders(headers),
-          body: this[kLastBody]
-        })
-        if (this.closed) {
-          destroyMaybe(this)
-        }
-        return skipBody
-      }
-
-      this.parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
-        this[kLastBody].push(chunk.slice(offset, offset + length))
-      }
-
-      this.parser[HTTPParser.kOnMessageComplete] = () => {
-        const body = this[kLastBody]
-        this[kLastBody] = null
-        if (body !== null) {
-          body.push(null)
-        }
-        if (this.closed) {
-          destroyMaybe(this)
-        }
-      }
-    }
-    this[kResetParser]()
+    resetParser(this)
 
     this[kRead] = () => {
       var socket = this.socket
@@ -424,6 +382,46 @@ function parseHeaders (headers) {
 }
 
 module.exports = Client
+
+function resetParser (client) {
+  client.parser = new HTTPParser(HTTPParser.RESPONSE)
+  client.parser[HTTPParser.kOnHeaders] = () => {}
+  client.parser[HTTPParser.kOnHeadersComplete] = ({ statusCode, headers }) => {
+    // TODO move client[kInflight] from being an array. The array allocation
+    // is showing up in the flamegraph.
+    const { request, callback } = client[kInflight].shift()
+    const skipBody = request.method === 'HEAD'
+
+    if (!skipBody) {
+      client[kLastBody] = new client[kStream].Readable({ read: client[kRead] })
+      client[kLastBody].push = request.wrapSimple(client[kLastBody], client[kLastBody].push)
+    }
+    callback(null, {
+      statusCode,
+      headers: parseHeaders(headers),
+      body: client[kLastBody]
+    })
+    if (client.closed) {
+      destroyMaybe(client)
+    }
+    return skipBody
+  }
+
+  client.parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
+    client[kLastBody].push(chunk.slice(offset, offset + length))
+  }
+
+  client.parser[HTTPParser.kOnMessageComplete] = () => {
+    const body = client[kLastBody]
+    client[kLastBody] = null
+    if (body !== null) {
+      body.push(null)
+    }
+    if (client.closed) {
+      destroyMaybe(client)
+    }
+  }
+}
 
 function destroyMaybe (client) {
   if (


### PR DESCRIPTION
Not sure what you prefer, but resetParser doesn't need to live on the object and take up an unnecessary property.