### PR TITLE
fix: request body edge cases

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,6 +18,8 @@ const kLastBody = Symbol('lastBody')
 const kStream = Symbol('kStream')
 const kClosed = Symbol('kClosed')
 
+function nop () {}
+
 function connect (client) {
   var socket = null
   var url = client.url
@@ -77,7 +79,7 @@ function reconnect (client, err) {
   client.socket.removeAllListeners('end')
   client.socket.removeAllListeners('finish')
   client.socket.removeAllListeners('error')
-  client.socket.on('error', () => {})
+  client.socket.on('error', nop)
   client.socket = null
 
   // we reset the callbacks
@@ -138,6 +140,11 @@ class Client extends EventEmitter {
       const callback = request.wrap(cb)
       this[kInflight].push({ request, callback })
 
+      if (this.socket.destroyed) {
+        // Socket finisher will invoke inflight.
+        return
+      }
+
       const { method, path, body } = request
       const headers = request.headers || {}
       this.socket.cork()
@@ -163,60 +170,78 @@ class Client extends EventEmitter {
         this.socket.write(body)
         endRequest()
       } else if (body && typeof body.pipe === 'function') {
-        const cleanup = this[kStream].finished(this.socket, (err) => {
-          if (err) {
-            body.destroy(err)
-          }
-        })
-
         if (chunked) {
           this.socket.write('transfer-encoding: chunked\r\n', 'ascii')
         } else {
           this.socket.write('\r\n', 'ascii')
         }
 
-        // TODO we should pause the queue while we are piping
+        // TODO: Pause the queue while piping.
+
+        let finished = false
+
+        const socket = this.socket
+
         const onData = (chunk) => {
           if (chunked) {
-            this.socket.write('\r\n' + Buffer.byteLength(chunk).toString(16) + '\r\n')
+            socket.write('\r\n' + Buffer.byteLength(chunk).toString(16) + '\r\n')
           }
-          if (!this.socket.write(chunk)) {
+          if (!socket.write(chunk)) {
             body.pause()
           }
         }
         const onDrain = () => {
           body.resume()
         }
+        const onFinished = (err) => {
+          if (finished) {
+            return
+          }
+          finished = true
 
-        body.on('data', onData)
-        this.socket.on('drain', onDrain)
+          freeSocketFinished()
+          freeBodyFinished()
 
-        this.socket.uncork()
-        this[kStream].finished(body, (err) => {
-          cleanup()
+          socket
+            .removeListener('drain', onDrain)
+          body
+            .removeListener('data', onData)
+            .removeListener('end', onFinished)
+
           if (err) {
+            if (typeof body.destroy === 'function') {
+              body.destroy(err)
+            }
+
             // TODO we might want to wait before previous in-flight
             // requests are finished before destroying
-            if (this.socket) {
-              finishedSocket(this, cb)
-              this.socket.destroy(err)
+            if (socket) {
+              finishedSocket(socket, callback)
+              socket.destroy(err)
             } else {
               callback(err, null)
             }
-            return
+          } else {
+            if (chunked) {
+              socket.cork()
+              socket.write('\r\n0\r\n', 'ascii')
+            }
+
+            endRequest()
           }
+        }
 
-          assert(this.socket)
+        body
+          .on('data', onData)
+          .on('end', onFinished)
+          .on('error', nop)
 
-          this.socket.removeListener('drain', onDrain)
+        socket
+          .on('drain', onDrain)
+          .uncork()
 
-          if (chunked) {
-            this.socket.cork()
-            this.socket.write('\r\n0\r\n', 'ascii')
-          }
-
-          endRequest()
-        })
+        const freeSocketFinished = this[kStream].finished(socket, onFinished)
+        const freeBodyFinished = this[kStream].finished(body, onFinished)
       } else {
         assert(!body)
         endRequest()
@@ -289,7 +314,7 @@ class Client extends EventEmitter {
     destroyMaybe(this)
 
     if (this.socket) {
-      finishedSocket(this, cb)
+      finishedSocket(this.socket, cb)
     } else {
       process.nextTick(cb, null)
     }
@@ -318,7 +343,7 @@ class Client extends EventEmitter {
     this.destroyed = true
 
     if (this.socket) {
-      finishedSocket(this, cb)
+      finishedSocket(this.socket, cb)
       this.socket.destroy(err)
     } else {
       process.nextTick(cb, err)
@@ -426,8 +451,7 @@ function destroyMaybe (client) {
   }
 }
 
-function finishedSocket (client, cb) {
-  const socket = client.socket
+function finishedSocket (socket, cb) {
   if (socket[kClosed]) {
     process.nextTick(cb, null)
   } else {


### PR DESCRIPTION
Readable can emit 'end' after .destroy() as well
as legacy streams might not implement the whole
Readable contract properly. Try to handle these
edge cases better.

Fixes: https://github.com/mcollina/undici/issues/66