### PR TITLE
refactor: encapsulate parser to connection

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -32,6 +32,8 @@ function _connect (client) {
     socket = net.connect(url.port || 80, url.hostname)
   }
 
+  const parser = client._parser = new HTTPParser(HTTPParser.RESPONSE)
+
   client.socket = socket
 
   socket[kClosed] = false
@@ -46,7 +48,7 @@ function _connect (client) {
       client[kQueue].resume()
     })
     .on('data', function (chunk) {
-      const err = client.parser.execute(chunk)
+      const err = parser.execute(chunk)
       if (err instanceof Error) {
         this.destroy(err)
       }
@@ -55,8 +57,118 @@ function _connect (client) {
       socket[kClosed] = true
     })
 
+  client[kQueue].pause()
+  client[kLastBody] = null
+
+  let body = null
+
+  parser[HTTPParser.kOnHeaders] = () => {}
+  parser[HTTPParser.kOnHeadersComplete] = ({ statusCode, headers }) => {
+    // TODO move client[kInflight] from being an array. The array allocation
+    // is showing up in the flamegraph.
+    const { request, callback } = client[kInflight].shift()
+    const skipBody = request.method === 'HEAD'
+
+    if (!skipBody) {
+      body = client[kLastBody] = new client[kStream].Readable({
+        autoDestroy: true,
+        read () {
+          socket.resume()
+        },
+        destroy (err, cb) {
+          if (client[kLastBody] === this) {
+            socket.resume()
+            client[kLastBody] = null
+          }
+
+          if (!err && !this._readableState.endEmitted) {
+            err = new Error('aborted')
+          }
+
+          cb(err, null)
+        }
+      })
+      body.push = request.wrapSimple(body, body.push)
+    }
+    callback(null, {
+      statusCode,
+      headers: parseHeaders(headers),
+      body
+    })
+    destroyMaybe(client)
+    return skipBody
+  }
+
+  parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
+    if (body.destroyed) {
+      // TODO: Add test and limit how much is read while response
+      // body is destroyed.
+      return
+    }
+
+    if (!body.push(chunk.slice(offset, offset + length))) {
+      socket.pause()
+    }
+  }
+
+  parser[HTTPParser.kOnMessageComplete] = () => {
+    if (body) {
+      body.push(null)
+      body = null
+
+      // TODO: Remove this and force consumer to fully consume body.
+      client[kLastBody] = null
+    }
+    destroyMaybe(client)
+  }
+
   client[kStream].finished(socket, (err) => {
-    reconnect(client, err)
+    err = err || new Error('other side closed')
+
+    client[kQueue].pause()
+
+    if (body) {
+      body.destroy(err)
+      body = null
+
+      // TODO: Remove this and force consumer to fully consume body.
+      client[kLastBody] = null
+    }
+
+    client._parser = null
+
+    if (client.destroyed) {
+      // reset callbacks
+      const inflight = client[kInflight].splice(0)
+      for (const { callback } of inflight) {
+        callback(err, null)
+      }
+      // flush queue
+      // TODO: Forward err?
+      client[kQueue].resume()
+      return
+    }
+
+    // reset events
+    client.socket.removeAllListeners('data')
+    client.socket.removeAllListeners('end')
+    client.socket.removeAllListeners('finish')
+    client.socket.removeAllListeners('error')
+    client.socket.on('error', nop)
+    client.socket = null
+
+    // we reset the callbacks
+    const inflight = client[kInflight].splice(0)
+
+    if (client[kQueue].length() > 0) {
+      connect(client)
+    }
+
+    for (const { callback } of inflight) {
+      callback(err, null)
+    }
+
+    client.emit('reconnect')
   })
 }
 
@@ -71,46 +183,6 @@ function connect (client) {
     _connect(client)
     client[kRetryDelay] = 1e3
   }
-}
-
-function reconnect (client, err) {
-  err = err || new Error('other side closed')
-
-  // stop the queue and reset the parsing state
-  reset(client, err)
-
-  if (client.destroyed) {
-    // reset callbacks
-    const inflight = client[kInflight].splice(0)
-    for (const { callback } of inflight) {
-      callback(err, null)
-    }
-    // flush queue
-    // TODO: Forward err?
-    client[kQueue].resume()
-    return
-  }
-
-  // reset events
-  client.socket.removeAllListeners('data')
-  client.socket.removeAllListeners('end')
-  client.socket.removeAllListeners('finish')
-  client.socket.removeAllListeners('error')
-  client.socket.on('error', nop)
-  client.socket = null
-
-  // we reset the callbacks
-  const inflight = client[kInflight].splice(0)
-
-  if (client[kQueue].length() > 0) {
-    connect(client)
-  }
-
-  for (const { callback } of inflight) {
-    callback(err, null)
-  }
-
-  client.emit('reconnect')
 }
 
 class Client extends EventEmitter {
@@ -275,7 +347,7 @@ class Client extends EventEmitter {
       }
     }
 
-    reset(this)
+    this[kQueue].pause()
   }
 
   get pipelining () {
@@ -393,78 +465,9 @@ function parseHeaders (headers) {
 
 module.exports = Client
 
-function reset (client, err) {
-  client[kQueue].pause()
-  if (client[kLastBody]) {
-    client[kLastBody].destroy(err)
-  }
-  client[kLastBody] = null
-
-  client.parser = new HTTPParser(HTTPParser.RESPONSE)
-  client.parser[HTTPParser.kOnHeaders] = () => {}
-  client.parser[HTTPParser.kOnHeadersComplete] = ({ statusCode, headers }) => {
-    // TODO move client[kInflight] from being an array. The array allocation
-    // is showing up in the flamegraph.
-    const { request, callback } = client[kInflight].shift()
-    const skipBody = request.method === 'HEAD'
-
-    if (!skipBody) {
-      client[kLastBody] = new client[kStream].Readable({
-        read () {
-          if (client.socket) {
-            client.socket.resume()
-          }
-        },
-        destroy (err, cb) {
-          if (client[kLastBody] === this && client.socket) {
-            client.socket.resume()
-          }
-          if (!err && !this.readableEnded) {
-            err = new Error('aborted')
-          }
-          cb(err, null)
-        }
-      })
-      client[kLastBody].push = request.wrapSimple(client[kLastBody], client[kLastBody].push)
-    }
-    callback(null, {
-      statusCode,
-      headers: parseHeaders(headers),
-      body: client[kLastBody]
-    })
-    if (client.closed) {
-      destroyMaybe(client)
-    }
-    return skipBody
-  }
-
-  client.parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
-    const body = client[kLastBody]
-    if (body.destroyed) {
-      // TODO: Add test and limit how much is read while response
-      // body is destroyed.
-      return
-    }
-
-    if (!body.push(chunk.slice(offset, offset + length))) {
-      client.socket.pause()
-    }
-  }
-
-  client.parser[HTTPParser.kOnMessageComplete] = () => {
-    const body = client[kLastBody]
-    client[kLastBody] = null
-    if (body !== null) {
-      body.push(null)
-    }
-    if (client.closed) {
-      destroyMaybe(client)
-    }
-  }
-}
-
 function destroyMaybe (client) {
   if (
+    client.closed &&
     !client[kLastBody] &&
     client[kQueue].length() === 0 &&
     client[kInflight].length === 0

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -390,14 +390,13 @@ test('GET errors body', (t) => {
 })
 
 test('reset parser', (t) => {
-  t.plan(4)
+  t.plan(6)
 
   const server = createServer()
-  server.once('request', (req, res) => {
+  let res2
+  server.on('request', (req, res) => {
+    res2 = res
     res.write('asd')
-    setTimeout(() => {
-      res.destroy()
-    }, 19)
   })
   t.tearDown(server.close.bind(server))
 
@@ -405,16 +404,28 @@ test('reset parser', (t) => {
     const client = new Client(`http://localhost:${server.address().port}`)
     t.tearDown(client.close.bind(client))
 
-    client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
+    client.request({ path: '/', method: 'GET' }, (err, { body }) => {
       t.error(err)
+      res2.destroy()
       body.resume()
       body.on('error', err => {
         t.ok(err)
       })
     })
-    client.on('reconnect', () => {
-      t.ok(!client.parser.chunk)
-      t.ok(!client.parser.offset)
+    client.once('reconnect', () => {
+      client.request({ path: '/', method: 'GET' }, (err, { body }) => {
+        t.error(err)
+        res2.destroy()
+        body.resume()
+        body.on('error', err => {
+          t.ok(err)
+        })
+      })
+
+      client.on('connect', () => {
+        t.ok(!client._parser.chunk)
+        t.ok(!client._parser.offset)
+      })
     })
   })
 })


### PR DESCRIPTION
The parser is dependent on the socket and not the client. This
refactors the connection to properly encapsulate state to the
connection and not to the client.

Avoid having to check for !client.socket etc...