### PR TITLE
fix: response handling …

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -64,8 +64,9 @@ function _connect (client) {
 
   client[kQueue].pause()
 
-  let body = null
-  let read = 0
+  let _body = null
+  let _read = 0
+  let _callback = null
 
   parser[HTTPParser.kOnHeaders] = () => {}
   parser[HTTPParser.kOnHeadersComplete] = ({ statusCode, headers }) => {
@@ -75,7 +76,7 @@ function _connect (client) {
     const skipBody = request.method === 'HEAD'
 
     if (!skipBody) {
-      body = new client[kStream].Readable({
+      _body = new client[kStream].Readable({
         autoDestroy: true,
         read () {
           socket.resume()
@@ -91,43 +92,52 @@ function _connect (client) {
             err = new Error('aborted')
           }
 
-          callback()
-
           cb(err, null)
         }
       })
-      body.push = request.wrapSimple(body, body.push)
+      _body.push = request.wrapSimple(_body, _body.push)
     }
 
     request.callback(null, {
       statusCode,
       headers: parseHeaders(headers),
-      body
+      body: _body
     })
 
     if (skipBody) {
       callback()
+    } else {
+      _callback = callback
     }
 
     return skipBody
   }
 
   parser[HTTPParser.kOnBody] = (chunk, offset, length) => {
-    read += length
+    _read += length
 
-    if (body.destroyed) {
-      if (read > client.maxAbortedPayload) {
+    if (_body.destroyed) {
+      if (_read > client.maxAbortedPayload) {
         socket.destroy()
       }
-    } else if (!body.push(chunk.slice(offset, offset + length))) {
+    } else if (!_body.push(chunk.slice(offset, offset + length))) {
       socket.pause()
     }
   }
 
   parser[HTTPParser.kOnMessageComplete] = () => {
-    if (body) {
-      body.push(null)
-      body = null
+    if (_body) {
+      // Stop Readable from emitting 'end' when destroyed.
+      if (!_body.destroyed) {
+        _body.push(null)
+      }
+      _body = null
+      _read = 0
+    }
+
+    if (_callback) {
+      _callback()
+      _callback = null
     }
   }
 
@@ -136,9 +146,15 @@ function _connect (client) {
 
     client[kQueue].pause()
 
-    if (body) {
-      body.destroy(err)
-      body = null
+    if (_body) {
+      _body.destroy(err)
+      _body = null
+      _read = 0
+    }
+
+    if (_callback) {
+      _callback()
+      _callback = null
     }
 
     client._parser = null

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -566,10 +566,8 @@ test('socket fail while ending request body', (t) => {
       t.strictEqual(err, _err)
     })
     client.close((err) => {
-      console.error(1)
       t.ok(err)
       client.close((err) => {
-        console.error(2, err)
         t.error(err)
       })
     })


### PR DESCRIPTION
    - Don't emit 'end' if aborted.
    - Don't start the next request until aborted res
      is read or connection is reset.
    - Reset max payload counter after each request.