### PR TITLE
fix: broken assertion

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -197,10 +197,10 @@ function _connect (client) {
   client[kQueue].pause()
 
   client[kStream].finished(socket, (err) => {
-    assert(err)
+    err = err || new Error('other side closed')
 
-    client._parser.destroy(err)
-    client._socket.destroy(err)
+    parser.destroy(err)
+    socket.destroy(err)
 
     if (client.destroyed) {
       client[kQueue].resume()


### PR DESCRIPTION
finished will be invoked on 'end' while destroy(err) will be delayed.
This can break the assertion in theory on edge cases.