### PR TITLE
feat: request.consume

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,51 @@ they fail due to indirect failure from the request
 at the head of the pipeline. This does not apply to
 idempotent requests with a stream request body.
 
+<a name='stream'></a>
+#### `client.stream(opts, cb(err, data))`
+
+A faster version of `'request'`. Not promisified.
+
+Unlike `request` this method expects `callback`
+to return a `Writable` which the response will be
+written to. This improves performance by avoiding
+creating an intermediate `Readable` when the user
+expects to directly pipe the response to a 
+`Writable`.
+
+```js
+const { Client } = require('undici')
+const client = new Client(`http://localhost:3000`)
+const fs = require('fs')
+const { finished } = require('stream')
+
+client.stream({
+  path: '/',
+  method: 'GET'
+}, function (err, data) {
+  if (err) {
+    console.error('failure', err)
+    return
+  }
+  const {
+    statusCode,
+    headers
+  } = data
+
+  console.log('response received', statusCode)
+  console.log('headers', headers)
+  const dst = fs.createWriteStream('destination.raw')
+  finished(dst, (err) => {
+    if (err) {
+      console.error('failure', err)
+    } else {
+      console.log('success')
+    }
+  })
+  return dst
+})
+````
+
 #### `client.pipelining`
 
 Property to get and set the pipelining factor.

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,6 +15,7 @@ const {
   kQueue,
   kTimeout,
   kTLSOpts,
+  kWrite,
   kClosed,
   kDestroyed,
   kInflight,
@@ -37,20 +38,9 @@ class Parser extends HTTPParser {
 
     this.client = client
     this.socket = socket
+    this.resume = () => socket.resume()
     this.read = 0
     this.body = null
-    this.bodyRead = function () {
-      socket.resume()
-    }
-    this.bodyDestroy = function (err, cb) {
-      socket.resume()
-
-      if (!err && !this._readableState.endEmitted) {
-        err = new Error('aborted')
-      }
-
-      cb(err, null)
-    }
   }
 
   [HTTPParser.kOnHeaders] () {
@@ -62,24 +52,42 @@ class Parser extends HTTPParser {
     const request = client[kQueue][client[kComplete]]
     const skipBody = request.method === 'HEAD'
 
-    const body = new Readable({
-      autoDestroy: true,
-      read: this.bodyRead,
-      destroy: this.bodyDestroy
-    })
-    body.push = request.wrapSimple(body, body.push)
-
-    this.body = body
     this.read = 0
-
-    request.callback(null, {
+    const body = request.callback(null, {
       statusCode,
-      headers: parseHeaders(headers),
-      body
+      headers: parseHeaders(headers)
     })
 
-    if (skipBody) {
-      this[HTTPParser.kOnMessageComplete]()
+    if (body && typeof body.write === 'function') {
+      if (skipBody) {
+        body.end()
+      } else {
+        body
+          .on('drain', this.resume)
+          // TODO: 'error' and 'close' should only resume if waiting for 'drain'.
+          .on('error', this.resume)
+          .on('close', this.resume)
+        body[kWrite] = request.wrapSimple(body, function (chunk) {
+          if (chunk == null) {
+            this.end()
+          } else {
+            this.write(chunk)
+          }
+        })
+        this.body = body
+      }
+    } else if (body && typeof body.read === 'function') {
+      if (skipBody) {
+        body.push(null)
+      } else {
+        body._read = this.resume
+        body[kWrite] = request.wrapSimple(body, body.push)
+        this.body = body
+      }
+    }
+
+    if (!this.body) {
+      this.next()
     }
 
     return skipBody
@@ -88,18 +96,17 @@ class Parser extends HTTPParser {
   [HTTPParser.kOnBody] (chunk, offset, length) {
     this.read += length
     const { client, socket, body, read } = this
-
-    if (body.destroyed) {
+    if (!body || body.destroyed) {
       if (read > client[kMaxAbortedPayload]) {
         socket.destroy()
       }
-    } else if (!body.push(chunk.slice(offset, offset + length))) {
+    } else if (!body[kWrite](chunk.slice(offset, offset + length))) {
       socket.pause()
     }
   }
 
   [HTTPParser.kOnMessageComplete] () {
-    const { client, socket, body } = this
+    const { body } = this
 
     if (!body) {
       return
@@ -108,11 +115,15 @@ class Parser extends HTTPParser {
     this.body = null
     this.read = 0
 
-    if (body.destroyed) {
-      // Stop Readable from emitting 'end' when destroyed.
-    } else {
-      body.push(null)
+    if (!body.destroyed) {
+      body[kWrite](null)
     }
+
+    this.next()
+  }
+
+  next () {
+    const { client, socket } = this
 
     socket.resume()
 
@@ -491,7 +502,27 @@ class Client extends EventEmitter {
         })
       })
     }
+    return this.stream(opts, (err, data) => {
+      if (err) {
+        cb(err, null)
+      } else {
+        const { statusCode, headers } = data
+        const body = new Readable({
+          autoDestroy: true,
+          destroy (err, cb) {
+            if (!err && !this._readableState.endEmitted) {
+              err = new Error('aborted')
+            }
+            cb(err, null)
+          }
+        })
+        cb(null, { statusCode, headers, body })
+        return body
+      }
+    })
+  }
 
+  stream (opts, cb) {
     if (this[kClosed]) {
       process.nextTick(cb, new Error('The client is closed'), null)
       return false

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -15,5 +15,6 @@ module.exports = {
   kSocket: Symbol('socket'),
   kParser: Symbol('parser'),
   kRetryTimeout: Symbol('retry timeout'),
-  kMaxAbortedPayload: Symbol('max aborted payload')
+  kMaxAbortedPayload: Symbol('max aborted payload'),
+  kWrite: Symbol('write')
 }

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -1,0 +1,179 @@
+'use strict'
+
+const { test } = require('tap')
+const { Client } = require('..')
+const { createServer } = require('http')
+const { PassThrough } = require('stream')
+
+test('stream get', (t) => {
+  t.plan(7)
+
+  const server = createServer((req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    t.strictEqual('localhost', req.headers.host)
+    res.setHeader('content-type', 'text/plain')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      const pt = new PassThrough()
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+      const bufs = []
+      pt.on('data', (buf) => {
+        bufs.push(buf)
+      })
+      pt.on('end', () => {
+        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      })
+      return pt
+    })
+  })
+})
+
+test('stream get skip body', (t) => {
+  t.plan(12)
+
+  const server = createServer((req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    t.strictEqual('localhost', req.headers.host)
+    res.setHeader('content-type', 'text/plain')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+
+      // Don't return writable. Skip the body.
+    })
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+
+      // Don't return writable. Skip the body.
+    })
+  })
+})
+
+test('stream GET destroy res', (t) => {
+  t.plan(14)
+
+  const server = createServer((req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    t.strictEqual('localhost', req.headers.host)
+    res.setHeader('content-type', 'text/plain')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+
+      const pt = new PassThrough()
+      pt.on('error', (err) => {
+        t.ok(err)
+      })
+      setImmediate(() => {
+        pt.destroy(new Error('kaboom'))
+      })
+
+      return pt
+    })
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+
+      let ret = ''
+      const pt = new PassThrough()
+      pt.on('data', chunk => {
+        ret += chunk
+      }).on('end', () => {
+        t.strictEqual(ret, 'hello')
+      })
+
+      return pt
+    })
+  })
+})
+
+test('stream GET remote destroy', (t) => {
+  t.plan(4)
+
+  const server = createServer((req, res) => {
+    res.write('asd')
+    setImmediate(() => {
+      res.destroy()
+    })
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err, { statusCode, headers }) => {
+      t.error(err)
+      const pt = new PassThrough()
+      pt.on('error', (err) => {
+        t.ok(err)
+      })
+      return pt
+    })
+
+    client.stream({
+      path: '/',
+      method: 'GET'
+    }, (err) => {
+      t.error(err)
+      const pt = new PassThrough()
+      pt.on('error', (err) => {
+        t.ok(err)
+      })
+      return pt
+    })
+  })
+})


### PR DESCRIPTION
By providing a `resume` property on the callback response and making `body` a lazy factory getter; it's possible to avoid the intermediate `Readable`. This would speed up e.g. creating a proxy using undici.

e.g.

Pre this PS
```js
function proxy (req, res) {
  client.request(fromReq(req), ({ statusCode, headers, body }) => {
    res.writeHead(statusCode, headers)
    // Body is an intermediate Readable
    body
      .on('error', (err) => res.destroy(err))
      .pipe(res)
  })
}
```

With this PR:
```js
function proxy (req, res) {
  client.request(fromReq(req), ({ statusCode, headers, resume }) => {
    res.writeHead(statusCode, headers)
    return pipe(res, resume)
  })
}

function pipe(dst, resume) {
  dst.on('drain', resume)
  return (err, chunk) => {
    if (err) {
      dst.destroy(err)
    } else if (chunk == null) {
      dst.end()
    } else {
      return dst.write(chunk)
    }
  }
}
```

Or just allow returning a `Writable` in the callback which does the above implicitly.

```js
function proxy (req, res) {
  client.request(fromReq(req), ({ statusCode, headers }) => {
    res.writeHead(statusCode, headers)
    return res
  })
}
```

Doesn't change anything in the existing API. Is purely opt-in.

Benchmarks:

body (pre PR): requests: 10346.729ms
resume (post PR): requests: 8902.416ms