### PR TITLE
fix: pool should be depth first connected

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Client = require('./client')
-const current = Symbol('current')
 
 class Pool {
   constructor (url, opts = {}) {
@@ -18,19 +17,6 @@ class Pool {
       pipelining,
       timeout
     }))
-
-    for (const client of this.clients) {
-      client.on('drain', onDrain)
-    }
-
-    this.drained = []
-    this[current] = null
-
-    const that = this
-    function onDrain () {
-      // this is the client
-      that.drained.push(this)
-    }
   }
 
   request (opts, cb) {
@@ -43,23 +29,10 @@ class Pool {
       })
     }
 
-    if (this[current] === null) {
-      if (this.drained.length > 0) {
-        // LIFO QUEUE
-        // we use the last one that drained, because that's the one
-        // that is more probable to have an alive socket
-        this[current] = this.drained.pop()
-      } else {
-        // if no one drained recently, let's just pick one randomly
-        this[current] = this.clients[Math.floor(Math.random() * this.clients.length)]
-      }
-    }
-
-    const writeMore = this[current].request(opts, cb)
-
-    if (!writeMore) {
-      this[current] = null
-    }
+    (
+      this.clients.find(client => !client.full && client.connected) ||
+      this.clients[Math.floor(Math.random() * this.clients.length)]
+    ).request(opts, cb)
   }
 
   close () {


### PR DESCRIPTION
This does differ a bit from the previous implementation as it does not take `'drain'` into account. I will probably have to change it but wanted to see whether this makes sense.

Basically this will always priotize the first connection in the list assuming that's the one least likely to timeout and the one that is fully saturated.

I hope this will also sort out the flakiness.

Also prioritizes clients which are connected.