### PR TITLE
fix: pool should avoid opening connections

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -29,10 +29,24 @@ class Pool {
       })
     }
 
-    (
-      this.clients.find(client => !client.full && client.connected) ||
-      this.clients[Math.floor(Math.random() * this.clients.length)]
-    ).request(opts, cb)
+    let next
+    for (const client of this.clients) {
+      if (client.full) {
+        continue
+      }
+
+      next = client
+
+      if (client.connected) {
+        break
+      }
+    }
+
+    if (!next) {
+      next = this.clients[Math.floor(Math.random() * this.clients.length)]
+    }
+
+    next.request(opts, cb)
   }
 
   close () {


### PR DESCRIPTION
Noticed while testing that Pool would open lots of connections in the edge case where no client is connected.

If there is no connected client, pick the first one that is not full, instead of a random one.