### PR TITLE
refactor: improve client.stream API

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Options:
   [RFC7230](https://tools.ietf.org/html/rfc7230#section-6.3.2). Default: `1`.
 
 <a name='request'></a>
-#### `client.request(opts, cb(err, data))`
+#### `client.request(opts, callback(err, data))`
 
 Performs an HTTP request.
 
@@ -74,7 +74,7 @@ Headers are represented by an object like this:
 Keys are lowercased. Values are not modified.
 If you don't specify a `host` header, it will be derived from the `url` of the client instance.
 
-The `data` parameter in the callback is defined as follow:
+The `data` parameter in `callback` is defined as follow:
 
 * `statusCode`
 * `headers`
@@ -154,47 +154,40 @@ at the head of the pipeline. This does not apply to
 idempotent requests with a stream request body.
 
 <a name='stream'></a>
-#### `client.stream(opts, cb(err, data))`
+#### `client.stream(opts, factory(data), callback(err))`
 
-A faster version of `request`. Not promisified.
+A faster version of `request`.
 
-Unlike `request` this method expects `callback`
+Unlike `request` this method expects `factory`
 to return a `Writable` which the response will be
 written to. This improves performance by avoiding
 creating an intermediate `Readable` when the user
 expects to directly pipe the response body to a
 `Writable`.
 
+The `data` parameter in `factory` is defined as follow:
+
+* `statusCode`
+* `headers`
+
 ```js
 const { Client } = require('undici')
 const client = new Client(`http://localhost:3000`)
 const fs = require('fs')
-const { finished } = require('stream')
 
 client.stream({
   path: '/',
   method: 'GET'
-}, function (err, data) {
-  if (err) {
-    console.error('failure', err)
-    return
-  }
-  const {
-    statusCode,
-    headers
-  } = data
-
+}, ({ statusCode, headers }) => {
   console.log('response received', statusCode)
   console.log('headers', headers)
-  const dst = fs.createWriteStream('destination.raw')
-  finished(dst, (err) => {
-    if (err) {
-      console.error('failure', err)
-    } else {
-      console.log('success')
-    }
-  })
-  return dst
+  return fs.createWriteStream('destination.raw')
+}, (err) => {
+  if (err) {
+    console.error('failure', err)
+  } else {
+    console.log('success')
+  }
 })
 ````
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,6 @@ const { HTTPParser } = require('http-parser-js')
 const { EventEmitter } = require('events')
 const Request = require('./request')
 const assert = require('assert')
-const { Readable } = require('stream')
 
 const {
   kUrl,
@@ -500,27 +499,19 @@ class Client extends EventEmitter {
         })
       })
     }
-    return this.stream(opts, (err, data) => {
-      if (err) {
-        cb(err, null)
-      } else {
-        const { statusCode, headers } = data
-        const body = new Readable({
-          autoDestroy: true,
-          destroy (err, cb) {
-            if (!err && !this._readableState.endEmitted) {
-              err = new Error('aborted')
-            }
-            cb(err, null)
-          }
-        })
-        cb(null, { statusCode, headers, body })
-        return body
-      }
-    })
+
+    return this.stream(opts, null, cb)
   }
 
-  stream (opts, cb) {
+  stream (opts, factory, cb) {
+    if (cb === undefined) {
+      return new Promise((resolve, reject) => {
+        this.stream(opts, factory, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
     if (this[kClosed]) {
       process.nextTick(cb, new Error('The client is closed'), null)
       return false
@@ -536,7 +527,7 @@ class Client extends EventEmitter {
     }
 
     try {
-      this[kQueue].push(new Request(opts, cb))
+      this[kQueue].push(new Request(opts, factory, cb))
       resume(this)
     } catch (err) {
       process.nextTick(cb, err, null)

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { AsyncResource } = require('async_hooks')
+const { Readable, finished } = require('stream')
 
 const methods = [
   'ACL',
@@ -53,7 +54,7 @@ function isValidBody (body) {
 }
 
 class Request extends AsyncResource {
-  constructor (opts, callback) {
+  constructor (opts, factory, callback) {
     super('UNDICI_REQ')
 
     if (!opts) {
@@ -84,7 +85,7 @@ class Request extends AsyncResource {
 
     this.chunked = !headers || headers['content-length'] === undefined
 
-    this.callback = this.wrap(callback)
+    this.callback = this.wrapSimple({ callback, factory }, dispatch)
 
     this.idempotent = idempotent == null
       ? this.method === 'HEAD' || this.method === 'GET'
@@ -127,6 +128,42 @@ class Request extends AsyncResource {
       cb.call(that, a)
       this.emitAfter()
     }
+  }
+}
+
+function dispatch (err, data) {
+  if (err) {
+    this.callback(err, null)
+  } else if (this.factory) {
+    try {
+      const stream = this.factory(data)
+      if (stream) {
+        finished(stream, this.callback)
+        return stream
+      } else {
+        const callback = this.callback
+        this.callback = null
+        callback(null, null)
+      }
+    } catch (err) {
+      if (!this.callback) {
+        throw err
+      } else {
+        this.callback(err, null)
+      }
+    }
+  } else {
+    const body = new Readable({
+      autoDestroy: true,
+      destroy (err, cb) {
+        if (!err && !this._readableState.endEmitted) {
+          err = new Error('aborted')
+        }
+        cb(err, null)
+      }
+    })
+    this.callback(null, { ...data, body })
+    return body
   }
 }
 

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -24,9 +24,8 @@ test('stream get', (t) => {
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
+    }, ({ statusCode, headers }) => {
       const pt = new PassThrough()
-      t.error(err)
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
       const bufs = []
@@ -37,6 +36,8 @@ test('stream get', (t) => {
         t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
       })
       return pt
+    }, (err) => {
+      t.error(err)
     })
   })
 })
@@ -60,23 +61,25 @@ test('stream get skip body', (t) => {
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
-      t.error(err)
+    }, ({ statusCode, headers }) => {
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
 
       // Don't return writable. Skip the body.
+    }, (err) => {
+      t.error(err)
     })
 
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
-      t.error(err)
+    }, ({ statusCode, headers }) => {
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
 
       // Don't return writable. Skip the body.
+    }, (err) => {
+      t.error(err)
     })
   })
 })
@@ -100,8 +103,7 @@ test('stream GET destroy res', (t) => {
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
-      t.error(err)
+    }, ({ statusCode, headers }) => {
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
 
@@ -114,13 +116,14 @@ test('stream GET destroy res', (t) => {
       })
 
       return pt
+    }, (err) => {
+      t.ok(err)
     })
 
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
-      t.error(err)
+    }, ({ statusCode, headers }) => {
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
 
@@ -133,6 +136,8 @@ test('stream GET destroy res', (t) => {
       })
 
       return pt
+    }, (err) => {
+      t.error(err)
     })
   })
 })
@@ -155,25 +160,27 @@ test('stream GET remote destroy', (t) => {
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err, { statusCode, headers }) => {
-      t.error(err)
+    }, () => {
       const pt = new PassThrough()
       pt.on('error', (err) => {
         t.ok(err)
       })
       return pt
+    }, (err) => {
+      t.ok(err)
     })
 
     client.stream({
       path: '/',
       method: 'GET'
-    }, (err) => {
-      t.error(err)
+    }, () => {
       const pt = new PassThrough()
       pt.on('error', (err) => {
         t.ok(err)
       })
       return pt
+    }, (err) => {
+      t.ok(err)
     })
   })
 })


### PR DESCRIPTION
This improves the `client.stream` API at the cost of a slightly (negligible?) slower request dispatch.

```js
await client.stream({
  path: '/',
  method: 'GET'
}, ({ statusCode, headers }) => {
  console.log('response received', statusCode)
  console.log('headers', headers)
  return fs.createWriteStream('destination.raw')
})
```