### PR TITLE
fix: request.stream don't wait for 'end'

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -140,7 +140,7 @@ function dispatch (err, data, resume) {
       const stream = this.factory(data)
       if (stream) {
         stream.on('drain', resume)
-        finished(stream, (err) => {
+        finished(stream, { readable: false }, (err) => {
           if (!stream.destroyed) {
             stream.destroy(err)
             assert(stream.destroyed)


### PR DESCRIPTION
Fixes: https://github.com/mcollina/undici/issues/130
Fixes: https://github.com/mcollina/undici/issues/128