### PR TITLE
Some more cleanup

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -174,7 +174,13 @@ class Parser extends HTTPParser {
 }
 
 class Client extends EventEmitter {
-  constructor (url, opts = {}) {
+  constructor (url, {
+    maxAbortedPayload,
+    timeout,
+    pipelining,
+    https,
+    tls
+  } = {}) {
     super()
 
     if (!(url instanceof URL)) {
@@ -189,22 +195,22 @@ class Client extends EventEmitter {
       throw new Error('invalid url')
     }
 
-    if (opts.maxAbortedPayload != null && !Number.isFinite(opts.maxAbortedPayload)) {
+    if (maxAbortedPayload != null && !Number.isFinite(maxAbortedPayload)) {
       throw new Error('invalid maxAbortedPayload')
     }
 
-    if (opts.timeout != null && !Number.isFinite(opts.timeout)) {
+    if (timeout != null && !Number.isFinite(timeout)) {
       throw new Error('invalid timeout')
     }
 
     this[kParser] = null
     this[kSocket] = null
-    this[kPipelining] = opts.pipelining || 1
+    this[kPipelining] = pipelining || 1
     this[kUrl] = url
-    this[kTimeout] = opts.timeout || 30e3
+    this[kTimeout] = timeout || 30e3
     this[kClosed] = false
     this[kDestroyed] = false
-    this[kTLSOpts] = opts.tls || opts.https
+    this[kTLSOpts] = tls || https
     this[kRetryDelay] = 0
     this[kRetryTimeout] = null
     this[kOnDestroyed] = []
@@ -212,8 +218,7 @@ class Client extends EventEmitter {
     this[kQueue] = []
     this[kInflight] = 0
     this[kComplete] = 0
-    this[kMaxAbortedPayload] = opts.maxAbortedPayload != null
-      ? opts.maxAbortedPayload : 1e6
+    this[kMaxAbortedPayload] = maxAbortedPayload || 1e6
   }
 
   get pipelining () {

--- a/lib/client.js
+++ b/lib/client.js
@@ -340,7 +340,9 @@ function resume (client) {
   }
   socket.write(rawHeaders, 'ascii')
 
-  if (typeof body === 'string' || body instanceof Uint8Array) {
+  if (body == null) {
+    endRequest(client)
+  } else if (typeof body === 'string' || body instanceof Uint8Array) {
     if (chunked) {
       socket.write(`content-length: ${Buffer.byteLength(body)}\r\n\r\n`, 'ascii')
     } else {
@@ -414,8 +416,7 @@ function resume (client) {
       .on('close', onClose)
       .uncork()
   } else {
-    assert(!body)
-    endRequest(client)
+    assert(false)
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -173,6 +173,168 @@ class Parser extends HTTPParser {
   }
 }
 
+class Client extends EventEmitter {
+  constructor (url, opts = {}) {
+    super()
+
+    if (!(url instanceof URL)) {
+      url = new URL(url)
+    }
+
+    if (!/https?/.test(url.protocol)) {
+      throw new Error('invalid url')
+    }
+
+    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+      throw new Error('invalid url')
+    }
+
+    if (opts.maxAbortedPayload != null && !Number.isFinite(opts.maxAbortedPayload)) {
+      throw new Error('invalid maxAbortedPayload')
+    }
+
+    if (opts.timeout != null && !Number.isFinite(opts.timeout)) {
+      throw new Error('invalid timeout')
+    }
+
+    this[kParser] = null
+    this[kSocket] = null
+    this[kPipelining] = opts.pipelining || 1
+    this[kUrl] = url
+    this[kTimeout] = opts.timeout || 30e3
+    this[kClosed] = false
+    this[kDestroyed] = false
+    this[kTLSOpts] = opts.tls || opts.https
+    this[kRetryDelay] = 0
+    this[kRetryTimeout] = null
+    this[kOnDestroyed] = []
+    this[kWriting] = false
+    this[kQueue] = []
+    this[kInflight] = 0
+    this[kComplete] = 0
+    this[kMaxAbortedPayload] = opts.maxAbortedPayload != null
+      ? opts.maxAbortedPayload : 1e6
+  }
+
+  get pipelining () {
+    return this[kPipelining]
+  }
+
+  set pipelinig (value) {
+    this[kPipelining] = value
+    resume(this)
+  }
+
+  get connected () {
+    return this[kSocket] && !this[kSocket].connecting && !this[kSocket].destroyed
+  }
+
+  get pending () {
+    return this[kQueue].length - this[kInflight]
+  }
+
+  get running () {
+    return this[kInflight] - this[kComplete]
+  }
+
+  get size () {
+    return this[kQueue].length - this[kComplete]
+  }
+
+  get full () {
+    return this.size > this[kPipelining]
+  }
+
+  get destroyed () {
+    return this[kDestroyed]
+  }
+
+  get closed () {
+    return this[kClosed]
+  }
+
+  request (opts, cb) {
+    if (cb === undefined) {
+      return new Promise((resolve, reject) => {
+        this.request(opts, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    return this.stream(opts, null, cb)
+  }
+
+  stream (opts, factory, cb) {
+    if (cb === undefined) {
+      return new Promise((resolve, reject) => {
+        this.stream(opts, factory, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    if (this[kDestroyed]) {
+      process.nextTick(cb, new Error('The client is destroyed'), null)
+      return false
+    }
+
+    if (this[kClosed]) {
+      process.nextTick(cb, new Error('The client is closed'), null)
+      return false
+    }
+
+    if (!this[kSocket]) {
+      connect(this)
+    }
+
+    try {
+      this[kQueue].push(new Request(opts, factory, cb))
+      resume(this)
+    } catch (err) {
+      process.nextTick(cb, err, null)
+    }
+
+    return !this.full
+  }
+
+  close (cb) {
+    if (cb === undefined) {
+      return new Promise((resolve, reject) => {
+        this.close((err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    this[kClosed] = true
+
+    if (!this.size) {
+      destroy(this, null, cb)
+    } else {
+      resume(this)
+      this[kOnDestroyed].push(cb)
+    }
+  }
+
+  destroy (err, cb) {
+    if (typeof err === 'function') {
+      cb = err
+      err = null
+    }
+
+    if (cb === undefined) {
+      return new Promise((resolve, reject) => {
+        this.destroy(err, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    destroy(this, err, () => cb(null, null))
+  }
+}
+
 function _connect (client) {
   const { protocol, port, hostname } = client[kUrl]
   const socket = protocol === 'https:'
@@ -416,168 +578,6 @@ function resume (client) {
     client[kWriting] = true
   } else {
     assert(false)
-  }
-}
-
-class Client extends EventEmitter {
-  constructor (url, opts = {}) {
-    super()
-
-    if (!(url instanceof URL)) {
-      url = new URL(url)
-    }
-
-    if (!/https?/.test(url.protocol)) {
-      throw new Error('invalid url')
-    }
-
-    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
-      throw new Error('invalid url')
-    }
-
-    if (opts.maxAbortedPayload != null && !Number.isFinite(opts.maxAbortedPayload)) {
-      throw new Error('invalid maxAbortedPayload')
-    }
-
-    if (opts.timeout != null && !Number.isFinite(opts.timeout)) {
-      throw new Error('invalid timeout')
-    }
-
-    this[kParser] = null
-    this[kSocket] = null
-    this[kPipelining] = opts.pipelining || 1
-    this[kUrl] = url
-    this[kTimeout] = opts.timeout || 30e3
-    this[kClosed] = false
-    this[kDestroyed] = false
-    this[kTLSOpts] = opts.tls || opts.https
-    this[kRetryDelay] = 0
-    this[kRetryTimeout] = null
-    this[kOnDestroyed] = []
-    this[kWriting] = false
-    this[kQueue] = []
-    this[kInflight] = 0
-    this[kComplete] = 0
-    this[kMaxAbortedPayload] = opts.maxAbortedPayload != null
-      ? opts.maxAbortedPayload : 1e6
-  }
-
-  get pipelining () {
-    return this[kPipelining]
-  }
-
-  set pipelinig (value) {
-    this[kPipelining] = value
-    resume(this)
-  }
-
-  get connected () {
-    return this[kSocket] && !this[kSocket].connecting && !this[kSocket].destroyed
-  }
-
-  get pending () {
-    return this[kQueue].length - this[kInflight]
-  }
-
-  get running () {
-    return this[kInflight] - this[kComplete]
-  }
-
-  get size () {
-    return this[kQueue].length - this[kComplete]
-  }
-
-  get full () {
-    return this.size > this[kPipelining]
-  }
-
-  get destroyed () {
-    return this[kDestroyed]
-  }
-
-  get closed () {
-    return this[kClosed]
-  }
-
-  request (opts, cb) {
-    if (cb === undefined) {
-      return new Promise((resolve, reject) => {
-        this.request(opts, (err, data) => {
-          return err ? reject(err) : resolve(data)
-        })
-      })
-    }
-
-    return this.stream(opts, null, cb)
-  }
-
-  stream (opts, factory, cb) {
-    if (cb === undefined) {
-      return new Promise((resolve, reject) => {
-        this.stream(opts, factory, (err, data) => {
-          return err ? reject(err) : resolve(data)
-        })
-      })
-    }
-
-    if (this[kDestroyed]) {
-      process.nextTick(cb, new Error('The client is destroyed'), null)
-      return false
-    }
-
-    if (this[kClosed]) {
-      process.nextTick(cb, new Error('The client is closed'), null)
-      return false
-    }
-
-    if (!this[kSocket]) {
-      connect(this)
-    }
-
-    try {
-      this[kQueue].push(new Request(opts, factory, cb))
-      resume(this)
-    } catch (err) {
-      process.nextTick(cb, err, null)
-    }
-
-    return !this.full
-  }
-
-  close (cb) {
-    if (cb === undefined) {
-      return new Promise((resolve, reject) => {
-        this.close((err, data) => {
-          return err ? reject(err) : resolve(data)
-        })
-      })
-    }
-
-    this[kClosed] = true
-
-    if (!this.size) {
-      destroy(this, null, cb)
-    } else {
-      resume(this)
-      this[kOnDestroyed].push(cb)
-    }
-  }
-
-  destroy (err, cb) {
-    if (typeof err === 'function') {
-      cb = err
-      err = null
-    }
-
-    if (cb === undefined) {
-      return new Promise((resolve, reject) => {
-        this.destroy(err, (err, data) => {
-          return err ? reject(err) : resolve(data)
-        })
-      })
-    }
-
-    destroy(this, err, () => cb(null, null))
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -249,14 +249,6 @@ function connect (client) {
   }
 }
 
-const endRequest = (client) => {
-  client[kSocket].write('\r\n', 'ascii')
-  client[kSocket].uncork()
-
-  client[kWriting] = false
-  resume(client)
-}
-
 function resume (client) {
   if (client[kDestroyed]) {
     for (const { callback } of client[kQueue].splice(client[kInflight])) {
@@ -329,7 +321,6 @@ function resume (client) {
   }
 
   client[kInflight]++
-  client[kWriting] = true
 
   const socket = client[kSocket]
 
@@ -341,7 +332,9 @@ function resume (client) {
   socket.write(rawHeaders, 'ascii')
 
   if (body == null) {
-    endRequest(client)
+    socket.write('\r\n', 'ascii')
+    socket.uncork()
+    resume(client)
   } else if (typeof body === 'string' || body instanceof Uint8Array) {
     if (chunked) {
       socket.write(`content-length: ${Buffer.byteLength(body)}\r\n\r\n`, 'ascii')
@@ -349,7 +342,9 @@ function resume (client) {
       socket.write('\r\n')
     }
     socket.write(body)
-    endRequest(client)
+    socket.write('\r\n', 'ascii')
+    socket.uncork()
+    resume(client)
   } else if (body && typeof body.pipe === 'function') {
     if (chunked) {
       socket.write('transfer-encoding: chunked\r\n', 'ascii')
@@ -396,11 +391,13 @@ function resume (client) {
         resume(client)
       } else {
         if (chunked) {
-          socket.cork()
-          socket.write('\r\n0\r\n', 'ascii')
+          socket.write('\r\n0\r\n\r\n', 'ascii')
+        } else {
+          socket.write('\r\n', 'ascii')
         }
 
-        endRequest(client)
+        client[kWriting] = false
+        resume(client)
       }
     }
 
@@ -415,6 +412,8 @@ function resume (client) {
       .on('error', onFinished)
       .on('close', onClose)
       .uncork()
+
+    client[kWriting] = true
   } else {
     assert(false)
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -178,7 +178,6 @@ class Client extends EventEmitter {
     maxAbortedPayload,
     timeout,
     pipelining,
-    https,
     tls
   } = {}) {
     super()
@@ -210,7 +209,7 @@ class Client extends EventEmitter {
     this[kTimeout] = timeout || 30e3
     this[kClosed] = false
     this[kDestroyed] = false
-    this[kTLSOpts] = tls || https
+    this[kTLSOpts] = tls
     this[kRetryDelay] = 0
     this[kRetryTimeout] = null
     this[kOnDestroyed] = []

--- a/test/https.js
+++ b/test/https.js
@@ -38,37 +38,3 @@ test('https get with tls opts', (t) => {
     })
   })
 })
-
-test('https get with https opts', (t) => {
-  t.plan(6)
-
-  const server = createServer(pem, (req, res) => {
-    t.strictEqual('/', req.url)
-    t.strictEqual('GET', req.method)
-    res.setHeader('content-type', 'text/plain')
-    res.end('hello')
-  })
-  t.tearDown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`https://localhost:${server.address().port}`, {
-      https: {
-        rejectUnauthorized: false
-      }
-    })
-    t.tearDown(client.close.bind(client))
-
-    client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
-      t.error(err)
-      t.strictEqual(statusCode, 200)
-      t.strictEqual(headers['content-type'], 'text/plain')
-      const bufs = []
-      body.on('data', (buf) => {
-        bufs.push(buf)
-      })
-      body.on('end', () => {
-        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
-      })
-    })
-  })
-})


### PR DESCRIPTION
Please note `fix: remove https option`. I see future problems with having two names for the same option when useland modules start forwarding options upstream to undici and all of a sudden they have overlap of tls and https and unexpectedly lose options. Removes this ambiguity by just having one of the options.