### PR TITLE
refactor: remove EventEmitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,6 @@ invoking the callback.
 
 Returns a promise if no callback is provided.
 
-#### Events
-
-* `'drain'`, emitted when the queue is empty unless the client
-  is closed or destroyed.
-
 ### undici.Pool
 
 A pool of [`Client`][] connected to the same upstream target.

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,6 @@ const { URL } = require('url')
 const net = require('net')
 const tls = require('tls')
 const { HTTPParser } = require('http-parser-js')
-const EventEmitter = require('events')
 const Request = require('./request')
 const assert = require('assert')
 
@@ -173,15 +172,13 @@ class Parser extends HTTPParser {
   }
 }
 
-class Client extends EventEmitter {
+class Client {
   constructor (url, {
     maxAbortedPayload,
     timeout,
     pipelining,
     tls
   } = {}) {
-    super()
-
     if (!(url instanceof URL)) {
       url = new URL(url)
     }
@@ -358,7 +355,6 @@ function _connect (client) {
     .on('connect', function () {
       client[kRetryDelay] = 0
       client[kRetryTimeout] = null
-      client.emit('connect')
       resume(client)
     })
     .on('data', function (chunk) {
@@ -397,8 +393,6 @@ function _connect (client) {
       if (client.pending > 0) {
         connect(client)
       }
-
-      client.emit('reconnect')
     })
 }
 
@@ -430,7 +424,6 @@ function resume (client) {
       client[kQueue].length = 0
       client[kInflight] = 0
       client[kComplete] = 0
-      client.emit('drain')
     }
     return
   }

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const { Client } = require('..')
 const { createServer } = require('http')
 const { PassThrough } = require('stream')
+const { kSocket } = require('../lib/symbols')
 
 test('stream get', (t) => {
   t.plan(7)
@@ -217,7 +218,7 @@ test('stream response resume back pressure and non standard error', (t) => {
       t.ok(err)
     })
 
-    client.on('reconnect', () => {
+    client[kSocket].on('close', () => {
       t.pass()
     })
 

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -99,7 +99,7 @@ test('close waits until socket is destroyed', (t) => {
 
     makeRequest()
 
-    client.on('connect', () => {
+    client[kSocket].on('connect', () => {
       let done = false
       finished(client[kSocket], () => {
         done = true
@@ -171,9 +171,6 @@ test('close should call callback once finished', (t) => {
     t.ok(makeRequest())
     t.ok(!makeRequest())
 
-    client.on('drain', () => {
-      t.fail()
-    })
     client.close((err) => {
       t.strictEqual(err, null)
       t.strictEqual(client.closed, true)


### PR DESCRIPTION
Reduce API surface by removing event emitter and events. Only used for tests and there are otherwise to test the corresponding funcitonality.