### PR TITLE
feat: stream.pipeline

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -69,6 +69,26 @@ suite
       })
     }
   })
+  .add('undici - pipeline - pipe', {
+    defer: true,
+    fn: deferred => {
+      pool
+        .pipeline(undiciOptions, data => {
+          // Do nothing
+        })
+        .on('error', (err) => {
+          throw err
+        })
+        .end()
+        .pipe(new PassThrough())
+        .on('error', (err) => {
+          throw err
+        })
+        .once('finish', () => {
+          deferred.resolve()
+        })
+    }
+  })
   .add('undici - stream - pipe', {
     defer: true,
     fn: deferred => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,12 @@ const { HTTPParser } = require('http-parser-js')
 const EventEmitter = require('events')
 const Request = require('./request')
 const assert = require('assert')
-const { Readable, finished } = require('stream')
+const {
+  Readable,
+  Duplex,
+  PassThrough,
+  finished
+} = require('stream')
 
 const {
   kUrl,
@@ -325,6 +330,57 @@ class Client extends EventEmitter {
     }
 
     return !this.full
+  }
+
+  pipeline (opts, handler) {
+    if (typeof handler !== 'function') {
+      throw new Error('invalid handler')
+    }
+
+    const req = new PassThrough({ autoDestroy: true })
+    const res = new PassThrough({ autoDestroy: true })
+    const ret = new Duplex({
+      autoDestroy: true,
+      read () {
+        res.resume()
+      },
+      write (chunk, encoding, callback) {
+        return req.write(chunk, encoding, callback)
+      },
+      final (callback) {
+        req.end()
+        callback()
+      },
+      destroy (err, callback) {
+        req.destroy(err)
+        res.destroy(err)
+        callback()
+      }
+    })
+
+    res
+      .on('data', chunk => {
+        if (!ret.push(chunk)) {
+          res.pause()
+        }
+      })
+      .on('end', () => {
+        ret.push(null)
+      })
+
+    this.stream({
+      ...opts,
+      body: req
+    }, (data) => {
+      handler(data)
+      return res
+    }, (err) => {
+      if (err) {
+        ret.destroy(err)
+      }
+    })
+
+    return ret
   }
 
   stream (opts, factory, cb) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -38,6 +38,10 @@ class Pool {
     getNext(this).stream(opts, factory, cb)
   }
 
+  pipeline (opts, handler) {
+    return getNext(this).pipeline(opts, handler)
+  }
+
   request (opts, cb) {
     // needed because we need the return value from client.request
     if (cb === undefined) {

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { test } = require('tap')
+const { Client } = require('..')
+const { createServer } = require('http')
+const { pipeline, Readable, Writable } = require('stream')
+
+test('pipeline echo', (t) => {
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    req.pipe(res)
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    let res = ''
+    const buf = Buffer.alloc(1e6).toString()
+    pipeline(
+      new Readable({
+        read () {
+          this.push(buf)
+          this.push(null)
+        }
+      }),
+      client.pipeline({
+        path: '/',
+        method: 'PUT'
+      }, ({ statusCode, headers }) => {
+      }, (err) => {
+        t.error(err)
+      }),
+      new Writable({
+        write (chunk, encoding, callback) {
+          res += chunk.toString()
+          callback()
+        },
+        final (callback) {
+          t.strictEqual(buf, res)
+          callback()
+        }
+      }),
+      (err) => {
+        t.error(err)
+      }
+    )
+  })
+})
+
+test('pipeline invalid handler', (t) => {
+  t.plan(1)
+
+  const client = new Client('http://localhost:5000')
+  try {
+    client.pipeline({}, null)
+  } catch (err) {
+    t.ok(/handler/.test(err))
+  }
+})


### PR DESCRIPTION
Fixes: https://github.com/mcollina/undici/issues/106

```js
stream.pipeline(
  fs.createReadStream('source.raw'),
  client.pipeline({
    path: '/',
    method: 'PUT',
  }, ({ statusCode }) => {
    if (statusCode !== 201) {
      throw new Error('invalid response')
    }
  }),
  fs.createReadStream('response.raw'),
  (err) => {
    if (err) {
      console.error('failed')
    } else {
      console.log('succeeded')
    }
  }
)
```