### PR TITLE
fix: only destroy if err

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -112,11 +112,11 @@ class Parser extends HTTPParser {
         if (body) {
           body.on('drain', resumeSocket)
           finished(body, { readable: false }, (err) => {
-            if (!body.destroyed) {
-              body.destroy(err)
-              assert(body.destroyed)
-            }
             if (err) {
+              if (!body.destroyed) {
+                body.destroy(err)
+                assert(body.destroyed)
+              }
               process.nextTick(resumeSocket)
             }
             callback(err, null)

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -235,7 +235,7 @@ test('stream response resume back pressure and non standard error', (t) => {
 })
 
 test('stream waits only for writable side', (t) => {
-  t.plan(1)
+  t.plan(2)
 
   const server = createServer((req, res) => {
     res.end(Buffer.alloc(1e3))
@@ -246,13 +246,13 @@ test('stream waits only for writable side', (t) => {
     const client = new Client(`http://localhost:${server.address().port}`)
     t.tearDown(client.close.bind(client))
 
+    const pt = new PassThrough()
     client.stream({
       path: '/',
       method: 'GET'
-    }, () => {
-      return new PassThrough()
-    }, (err) => {
+    }, () => pt, (err) => {
       t.error(err)
+      t.strictEqual(pt.destroyed, false)
     })
   })
 })


### PR DESCRIPTION
Don't destroy readable side and closer mimic pipeline behavior.