### PR TITLE
unify impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Machine: 2.7 GHz Quad-Core Intel Core i7
 Configuration: Node v14.2, HTTP/1.1 without TLS, 100 connections
 
 ```
-http - keepalive - pipe x 5,658 ops/sec ±10.96% (69 runs sampled)
-undici - pipeline - pipe x 6,378 ops/sec ±7.10% (71 runs sampled)
-undici - request - pipe x 9,334 ops/sec ±6.37% (70 runs sampled)
-undici - stream - pipe x 10,805 ops/sec ±1.94% (75 runs sampled)
+http - keepalive - pipe x 5,120 ops/sec ±10.80% (65 runs sampled)
+undici - pipeline - pipe x 6,227 ops/sec ±11.44% (71 runs sampled)
+undici - request - pipe x 8,685 ops/sec ±8.96% (67 runs sampled)
+undici - stream - pipe x 11,453 ops/sec ±3.69% (79 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -74,7 +74,7 @@ suite
     fn: deferred => {
       pool
         .pipeline(undiciOptions, data => {
-          // Do nothing
+          return data.body
         })
         .on('error', (err) => {
           throw err

--- a/lib/client.js
+++ b/lib/client.js
@@ -281,7 +281,7 @@ class Client extends EventEmitter {
       throw new Error('invalid callback')
     }
 
-    return this.enqueue(opts, function (err, data, resume) {
+    this.enqueue(opts, function (err, data, resume) {
       if (err) {
         callback(err, null)
         return
@@ -316,6 +316,8 @@ class Client extends EventEmitter {
         }
       })
     })
+
+    return !this.full
   }
 
   pipeline (opts, handler) {
@@ -335,7 +337,7 @@ class Client extends EventEmitter {
         }
       },
       write (chunk, encoding, callback) {
-        return req.write(chunk, encoding, callback)
+        req.write(chunk, encoding, callback)
       },
       final (callback) {
         req.end()
@@ -352,15 +354,45 @@ class Client extends EventEmitter {
       }
     })
 
-    this.stream({ ...opts, body: req }, (data) => {
+    this.enqueue({ ...opts, body: req }, function (err, data, resume) {
+      if (err) {
+        ret.destroy(err)
+        return
+      }
+
       req = null
-      res = new PassThrough({ autoDestroy: true })
-      body = handler({ ...data, body: res })
+      res = new Readable({
+        autoDestroy: true,
+        read: resume,
+        destroy (err, callback) {
+          if (!err && !this._readableState.endEmitted) {
+            err = new Error('aborted')
+          }
+          if (err) {
+            process.nextTick(resume)
+          }
+          callback(err, null)
+        }
+      })
+
+      // TODO: Do we need wrap here?
+      res.destroy = this.wrap(res, res.destroy)
+
+      try {
+        body = handler({ ...data, body: res })
+      } catch (err) {
+        ret.destroy(err)
+        return
+      }
 
       if (!body) {
         ret.destroy(new Error('invalid body'))
         return
       }
+
+      // TODO: If body === res then avoid intermediate
+      // and write directly to ret.push? Or should this
+      // happen when body is null?
 
       body
         .on('data', function (chunk) {
@@ -377,11 +409,15 @@ class Client extends EventEmitter {
           ret.push(null)
         })
 
-      return res
-    }, (err) => {
-      if (err) {
-        ret.destroy(err)
-      }
+      return this.wrap(res, function (err, chunk) {
+        if (this.destroyed) {
+          return null
+        } else if (err) {
+          this.destroy(err)
+        } else {
+          return this.push(chunk)
+        }
+      })
     })
 
     return ret
@@ -408,7 +444,7 @@ class Client extends EventEmitter {
       throw new Error('invalid callback')
     }
 
-    return this.enqueue(opts, function (err, data, resume) {
+    this.enqueue(opts, function (err, data, resume) {
       if (err) {
         callback(err)
         return
@@ -454,6 +490,8 @@ class Client extends EventEmitter {
         }
       })
     })
+
+    return !this.full
   }
 
   enqueue (opts, callback) {
@@ -477,8 +515,6 @@ class Client extends EventEmitter {
     } catch (err) {
       process.nextTick(callback, err, null)
     }
-
-    return !this.full
   }
 
   close (cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,6 @@ const {
   kQueue,
   kTimeout,
   kTLSOpts,
-  kWrite,
   kClosed,
   kDestroyed,
   kInflight,
@@ -53,17 +52,23 @@ class Parser extends HTTPParser {
   }
 
   [HTTPParser.kOnHeadersComplete] ({ statusCode, headers }) {
-    const { client } = this
+    const { client, resumeSocket } = this
     const request = client[kQueue][client[kComplete]]
     const skipBody = request.method === 'HEAD'
 
     assert(!this.read)
     assert(!this.body)
 
-    let body = this.dispatch(request, statusCode, parseHeaders(headers))
+    let body = request.callback(null, {
+      statusCode,
+      headers: parseHeaders(headers),
+      opaque: request.opaque
+    }, resumeSocket)
+    request.callback = null
+    request.opaque = null
 
     if (body && skipBody) {
-      body[kWrite](null)
+      body(null, null)
       body = null
     }
 
@@ -78,12 +83,16 @@ class Parser extends HTTPParser {
 
   [HTTPParser.kOnBody] (chunk, offset, length) {
     this.read += length
+
     const { client, socket, body, read } = this
-    if (!body || body.destroyed) {
-      if (read > client[kMaxAbortedPayload]) {
-        socket.destroy()
-      }
-    } else if (!body[kWrite](chunk.slice(offset, offset + length))) {
+
+    const ret = body
+      ? body(null, chunk.slice(offset, offset + length))
+      : null
+
+    if (ret == null && read > client[kMaxAbortedPayload]) {
+      socket.destroy()
+    } else if (ret === false) {
       socket.pause()
     }
   }
@@ -94,71 +103,13 @@ class Parser extends HTTPParser {
     this.read = 0
     this.body = null
 
-    if (body && !body.destroyed) {
-      body[kWrite](null)
+    if (body) {
+      body(null, null)
     }
 
     if (body) {
       this.next()
     }
-  }
-
-  dispatch (request, statusCode, headers) {
-    const { resumeSocket } = this
-    const { callback, factory, opaque } = request
-    request.callback = null
-    request.factory = null
-    request.opaque = null
-
-    let body
-    if (factory) {
-      try {
-        body = factory({ statusCode, headers, opaque })
-        if (body) {
-          body.on('drain', resumeSocket)
-          finished(body, { readable: false }, (err) => {
-            if (err) {
-              if (!body.destroyed) {
-                body.destroy(err)
-                assert(body.destroyed)
-              }
-              process.nextTick(resumeSocket)
-            }
-            callback(err, null)
-          })
-          body.destroy = request.wrap(body, body.destroy)
-          body[kWrite] = request.wrap(body, function (chunk) {
-            if (chunk == null) {
-              this.end()
-            } else {
-              return this.write(chunk)
-            }
-          })
-        } else {
-          callback(null, null)
-        }
-      } catch (err) {
-        callback(err, null)
-      }
-    } else {
-      body = new Readable({
-        autoDestroy: true,
-        read: resumeSocket,
-        destroy (err, cb) {
-          if (!err && !this._readableState.endEmitted) {
-            err = new Error('aborted')
-          }
-          if (err) {
-            process.nextTick(resumeSocket)
-          }
-          cb(err, null)
-        }
-      })
-      body.destroy = request.wrap(body, body.destroy)
-      body[kWrite] = request.wrap(body, body.push)
-      callback(null, { statusCode, headers, body })
-    }
-    return body
   }
 
   next () {
@@ -173,6 +124,8 @@ class Parser extends HTTPParser {
 
   destroy (err) {
     const { client, body } = this
+
+    assert(err)
 
     if (client[kComplete] >= client[kInflight]) {
       assert(!body)
@@ -190,8 +143,8 @@ class Parser extends HTTPParser {
       if (callback) {
         assert(!body)
         process.nextTick(callback, err, null)
-      } else if (body && !body.destroyed) {
-        body.destroy(err)
+      } else if (body) {
+        body(err, null)
       }
     }
 
@@ -311,8 +264,8 @@ class Client extends EventEmitter {
     return this[kClosed]
   }
 
-  request (opts, cb) {
-    if (cb === undefined) {
+  request (opts, callback) {
+    if (callback === undefined) {
       return new Promise((resolve, reject) => {
         this.request(opts, (err, data) => {
           return err ? reject(err) : resolve(data)
@@ -324,32 +277,45 @@ class Client extends EventEmitter {
       throw new Error('invalid opts')
     }
 
-    if (typeof cb !== 'function') {
+    if (typeof callback !== 'function') {
       throw new Error('invalid callback')
     }
 
-    if (this[kDestroyed]) {
-      process.nextTick(cb, new Error('The client is destroyed'), null)
-      return false
-    }
+    return this.enqueue(opts, function (err, data, resume) {
+      if (err) {
+        callback(err, null)
+        return
+      }
 
-    if (this[kClosed]) {
-      process.nextTick(cb, new Error('The client is closed'), null)
-      return false
-    }
+      const body = new Readable({
+        autoDestroy: true,
+        read: resume,
+        destroy (err, callback) {
+          if (!err && !this._readableState.endEmitted) {
+            err = new Error('aborted')
+          }
+          if (err) {
+            process.nextTick(resume)
+          }
+          callback(err, null)
+        }
+      })
 
-    if (!this[kSocket]) {
-      connect(this)
-    }
+      // TODO: Do we need wrap here?
+      body.destroy = this.wrap(body, body.destroy)
 
-    try {
-      this[kQueue].push(new Request(opts, null, cb))
-      resume(this)
-    } catch (err) {
-      process.nextTick(cb, err, null)
-    }
+      callback(null, { ...data, body })
 
-    return !this.full
+      return this.wrap(body, function (err, chunk) {
+        if (this.destroyed) {
+          return null
+        } else if (err) {
+          this.destroy(err)
+        } else {
+          return this.push(chunk)
+        }
+      })
+    })
   }
 
   pipeline (opts, handler) {
@@ -421,8 +387,8 @@ class Client extends EventEmitter {
     return ret
   }
 
-  stream (opts, factory, cb) {
-    if (cb === undefined) {
+  stream (opts, factory, callback) {
+    if (callback === undefined) {
       return new Promise((resolve, reject) => {
         this.stream(opts, factory, (err, data) => {
           return err ? reject(err) : resolve(data)
@@ -438,17 +404,66 @@ class Client extends EventEmitter {
       throw new Error('invalid factory')
     }
 
-    if (typeof cb !== 'function') {
+    if (typeof callback !== 'function') {
       throw new Error('invalid callback')
     }
 
+    return this.enqueue(opts, function (err, data, resume) {
+      if (err) {
+        callback(err)
+        return
+      }
+
+      let body
+      try {
+        body = factory(data)
+      } catch (err) {
+        callback(err, null)
+        return
+      }
+
+      if (!body) {
+        callback(null, null)
+        return
+      }
+
+      body.on('drain', resume)
+      finished(body, { readable: false }, (err) => {
+        if (err) {
+          if (!body.destroyed) {
+            body.destroy(err)
+            assert(body.destroyed)
+          }
+          process.nextTick(resume)
+        }
+        callback(err, null)
+      })
+
+      // TODO: Do we need wrap here?
+      body.destroy = this.wrap(body, body.destroy)
+
+      return this.wrap(body, function (err, chunk) {
+        if (this.destroyed) {
+          return null
+        } else if (err) {
+          this.destroy(err)
+        } else if (chunk == null) {
+          this.end()
+        } else {
+          return this.write(chunk)
+        }
+      })
+    })
+  }
+
+  enqueue (opts, callback) {
     if (this[kDestroyed]) {
-      process.nextTick(cb, new Error('The client is destroyed'), null)
+      process.nextTick(callback, new Error('The client is destroyed'), null)
       return false
     }
 
     if (this[kClosed]) {
-      process.nextTick(cb, new Error('The client is closed'), null)
+      process.nextTick(callback, new Error('The client is closed'), null)
       return false
     }
 
@@ -457,10 +472,10 @@ class Client extends EventEmitter {
     }
 
     try {
-      this[kQueue].push(new Request(opts, factory, cb))
+      this[kQueue].push(new Request(opts, callback))
       resume(this)
     } catch (err) {
-      process.nextTick(cb, err, null)
+      process.nextTick(callback, err, null)
     }
 
     return !this.full

--- a/lib/request.js
+++ b/lib/request.js
@@ -50,7 +50,7 @@ function isValidBody (body) {
 }
 
 class Request extends AsyncResource {
-  constructor (opts, factory, callback) {
+  constructor (opts, callback) {
     super('UNDICI_REQ')
 
     if (!opts) {
@@ -81,9 +81,7 @@ class Request extends AsyncResource {
 
     this.chunked = !headers || headers['content-length'] === undefined
 
-    this.callback = this.wrap(undefined, callback)
-
-    this.factory = factory ? this.wrap(undefined, factory) : null
+    this.callback = this.wrap(this, callback)
 
     this.opaque = opaque
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -15,6 +15,5 @@ module.exports = {
   kSocket: Symbol('socket'),
   kParser: Symbol('parser'),
   kRetryTimeout: Symbol('retry timeout'),
-  kMaxAbortedPayload: Symbol('max aborted payload'),
-  kWrite: Symbol('write')
+  kMaxAbortedPayload: Symbol('max aborted payload')
 }


### PR DESCRIPTION
The old implementation was a bit ugly. This extracts the API specific parts to the `request`, `stream` and `pipeline` methods and keeps the "core" clean.

Fixes broken .pipeline benchmark.

Slightly improves .pipeline perf by replacing `PassThrough` with `Readable` for `res`. Also opens up for further future optimizations to replace `ret` and `req` with `Readable`.