### PR TITLE
perf: optimize stream.pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Machine: 2.7 GHz Quad-Core Intel Core i7
 Configuration: Node v14.2, HTTP/1.1 without TLS, 100 connections
 
 ```
-http - keepalive - pipe x 5,120 ops/sec ±10.80% (65 runs sampled)
-undici - pipeline - pipe x 6,227 ops/sec ±11.44% (71 runs sampled)
-undici - request - pipe x 8,685 ops/sec ±8.96% (67 runs sampled)
-undici - stream - pipe x 11,453 ops/sec ±3.69% (79 runs sampled)
+http - keepalive - pipe x 6,545 ops/sec ±12.47% (64 runs sampled)
+undici - pipeline - pipe x 9,560 ops/sec ±3.68% (77 runs sampled)
+undici - request - pipe x 9,797 ops/sec ±6.80% (77 runs sampled)
+undici - stream - pipe x 11,599 ops/sec ±0.89% (78 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).

--- a/lib/client.js
+++ b/lib/client.js
@@ -27,6 +27,7 @@ const {
   kUrl,
   kWriting,
   kQueue,
+  kResume,
   kTimeout,
   kTLSOpts,
   kClosed,
@@ -360,22 +361,40 @@ class Client extends EventEmitter {
       return new PassThrough().destroy(new InvalidArgumentError('invalid handler'))
     }
 
-    let req = new PassThrough({ autoDestroy: true })
+    let req = new Readable({
+      autoDestroy: true,
+      read () {
+        if (this[kResume]) {
+          const resume = this[kResume]
+          this[kResume] = null
+          resume()
+        }
+      },
+      destroy (err, callback) {
+        this._read()
+        callback(err)
+      }
+    })
     let res
     let body
 
     const ret = new Duplex({
       autoDestroy: true,
+      writableHighWaterMark: 1,
       read () {
         if (body) {
           body.resume()
         }
       },
       write (chunk, encoding, callback) {
-        req.write(chunk, encoding, callback)
+        if (req.push(chunk, encoding)) {
+          callback()
+        } else {
+          req[kResume] = callback
+        }
       },
       final (callback) {
-        req.end()
+        req.push(null)
         callback()
       },
       destroy (err, callback) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -8,6 +8,7 @@ module.exports = {
   kDestroyed: Symbol('destroyed'),
   kInflight: Symbol('inflight'),
   kComplete: Symbol('complete'),
+  kResume: Symbol('resume'),
   kError: Symbol('error'),
   kOnDestroyed: Symbol('destroy callbacks'),
   kPipelining: Symbol('pipelinig'),


### PR DESCRIPTION
- Make req Readable instead of PassThrough.
- Bypass Duplex writable buffering.

Brings stream.pipeline to parity with stream.requests.