### PR TITLE
fix: remove drain

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,9 +378,6 @@ called and the client shutdown has completed.
 
 #### Events
 
-* `'drain'`, emitted when `client.size` decreases to `0` and the client
-  is not closed or destroyed.
-
 * `'connect'`, emitted when a socket has been created and
   connected. The client will connect once `client.size > 0`.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -631,7 +631,7 @@ class Client extends EventEmitter {
 
     try {
       this[kQueue].push(new Request(opts, callback))
-      process.nextTick(resume, this)
+      resume(this)
     } catch (err) {
       process.nextTick(callback, err, null)
     }
@@ -769,7 +769,6 @@ function resume (client) {
       client[kQueue].length = 0
       client[kInflight] = 0
       client[kComplete] = 0
-      client.emit('drain')
     }
     return
   }

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -152,17 +152,20 @@ test('A client should enqueue as much as twice its pipelining factor', (t) => {
     t.notOk(makeRequest(), 'we must stop now')
     t.ok(client.full, 'client is full')
 
-    client.on('drain', () => {
-      t.ok(countGreaterThanOne, 'seen more than one parallel request')
-      const start = sent
-      for (; sent < start + 2 && sent < num;) {
-        t.notOk(client.full, 'client is not full')
-        t.ok(makeRequest())
-      }
-    })
-
     function makeRequest () {
-      return makeRequestAndExpectUrl(client, sent++, t, () => count--)
+      return makeRequestAndExpectUrl(client, sent++, t, () => {
+        count--
+        process.nextTick(() => {
+          if (client.size === 0) {
+            t.ok(countGreaterThanOne, 'seen more than one parallel request')
+            const start = sent
+            for (; sent < start + 2 && sent < num;) {
+              t.notOk(client.full, 'client is not full')
+              t.ok(makeRequest())
+            }
+          }
+        })
+      })
     }
   })
 })

--- a/test/client.js
+++ b/test/client.js
@@ -435,42 +435,6 @@ test('ignore request header mutations', (t) => {
   })
 })
 
-test('drain when queue is empty', (t) => {
-  t.plan(3)
-
-  const server = createServer((req, res) => {
-    res.end()
-  })
-  t.tearDown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`, {
-      pipelining: 1
-    })
-    t.tearDown(client.close.bind(client))
-
-    client.on('drain', () => {
-      t.strictEqual(client.size, 0)
-    })
-
-    client.request({
-      path: '/',
-      method: 'GET'
-    }, (err, { body }) => {
-      t.error(err)
-      body.resume()
-    })
-
-    client.request({
-      path: '/',
-      method: 'GET'
-    }, (err, { body }) => {
-      t.error(err)
-      body.resume()
-    })
-  })
-})
-
 test('url-like url', (t) => {
   t.plan(1)
 

--- a/test/close-and-destroy.js
+++ b/test/close-and-destroy.js
@@ -164,9 +164,6 @@ test('close should call callback once finished', (t) => {
     t.ok(makeRequest())
     t.ok(!makeRequest())
 
-    client.on('drain', () => {
-      t.fail()
-    })
     client.close((err) => {
       t.strictEqual(err, null)
       t.strictEqual(client.closed, true)


### PR DESCRIPTION
I'm not 100% `'drain'` is implemented correctly. Since I find its usefulness limited and it allows us to skip a `nextTick` I would prefer removing it.