### PR TITLE
fix: URL default port validation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -201,6 +201,10 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid url')
     }
 
+    if (url.port != null && url.port !== '' && !Number.isFinite(parseInt(url.port))) {
+      throw new InvalidArgumentError('invalid port')
+    }
+
     if (url.hostname != null && typeof url.hostname !== 'string') {
       throw new InvalidArgumentError('invalid hostname')
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -201,10 +201,6 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid url')
     }
 
-    if (url.port != null && !Number.isFinite(parseInt(url.port))) {
-      throw new InvalidArgumentError('invalid port')
-    }
-
     if (url.hostname != null && typeof url.hostname !== 'string') {
       throw new InvalidArgumentError('invalid hostname')
     }

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -241,7 +241,14 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
 })
 
 test('invalid options throws', (t) => {
-  t.plan(18)
+  t.plan(20)
+
+  try {
+    new Client({ port: 'foobar' }) // eslint-disable-line
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.strictEqual(err.message, 'invalid port')
+  }
 
   try {
     new Client(new URL('http://asd:200/somepath')) // eslint-disable-line

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -241,14 +241,7 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
 })
 
 test('invalid options throws', (t) => {
-  t.plan(20)
-
-  try {
-    new Client(new URL('asd://asd')) // eslint-disable-line
-  } catch (err) {
-    t.ok(err instanceof errors.InvalidArgumentError)
-    t.strictEqual(err.message, 'invalid port')
-  }
+  t.plan(18)
 
   try {
     new Client(new URL('http://asd:200/somepath')) // eslint-disable-line
@@ -790,5 +783,37 @@ test('invalid opts', (t) => {
     client.enqueue({ path: '/', method: 'GET', signal: {} }, null)
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
+  }
+})
+
+test('default port for http and https', (t) => {
+  t.plan(4)
+
+  try {
+    new Client(new URL('http://localhost:80')) // eslint-disable-line
+    t.pass('Should not throw')
+  } catch (err) {
+    t.fail(err)
+  }
+
+  try {
+    new Client(new URL('http://localhost')) // eslint-disable-line
+    t.pass('Should not throw')
+  } catch (err) {
+    t.fail(err)
+  }
+
+  try {
+    new Client(new URL('https://localhost:443')) // eslint-disable-line
+    t.pass('Should not throw')
+  } catch (err) {
+    t.fail(err)
+  }
+
+  try {
+    new Client(new URL('https://localhost')) // eslint-disable-line
+    t.pass('Should not throw')
+  } catch (err) {
+    t.fail(err)
   }
 })


### PR DESCRIPTION
The current port validation will fail if you use the default http/https port or not use a port at all, for example:
```js
undici('http://localhost')
undici('http://localhost:80')
undici('https://localhost')
undici('https://localhost:443')
```
All the examples above will throw an exception, even if the URL is valid.

Given that internally we are using the `URL` constructor, I think we should leave to it the bad port validation, for example, the following will cause an exception:
```js
undici('http://localhost:foobar')
```