### PR TITLE
fix: disconnect event w err

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,10 @@ called and the client shutdown has completed.
 * `'connect'`, emitted when a socket has been created and
   connected. The client will connect once `client.size > 0`.
 
-* `'reconnect'`, emitted when socket has disconnected. The
-  client will reconnect if or once `client.size > 0`.
+* `'disconnect'`, emitted when socket has disconnected. The
+  first argument of the event is the error which caused the
+  socket to disconnect. The client will reconnect if or once 
+  `client.size > 0`.
 
 <a name='pool'></a>
 ### `new undici.Pool(url, opts)`

--- a/lib/client.js
+++ b/lib/client.js
@@ -769,7 +769,7 @@ function _connect (client) {
         client[kRetryDelay] = Math.min(client[kRetryDelay] * 2 || 1e3, client[kSocketTimeout])
       }
 
-      client.emit('reconnect')
+      client.emit('disconnect', err)
     })
 }
 

--- a/test/client-abort.js
+++ b/test/client-abort.js
@@ -49,7 +49,7 @@ test('aborted GET maxAbortedPayload reset', (t) => {
     })
     t.tearDown(client.close.bind(client))
 
-    client.on('reconnect', () => {
+    client.on('disconnect', () => {
       t.fail()
     })
 
@@ -121,7 +121,7 @@ test('aborted GET maxAbortedPayload', (t) => {
         .on('error', () => {})
     })
 
-    client.on('reconnect', () => {
+    client.on('disconnect', () => {
       t.pass()
     })
 
@@ -168,7 +168,7 @@ test('aborted GET maxAbortedPayload less than HWM', (t) => {
         .on('error', () => {})
     })
 
-    client.on('reconnect', () => {
+    client.on('disconnect', () => {
       t.fail()
     })
 

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -469,7 +469,7 @@ test('reset parser', (t) => {
         t.ok(err)
       })
     })
-    client.once('reconnect', () => {
+    client.once('disconnect', () => {
       client.request({ path: '/', method: 'GET' }, (err, { body }) => {
         t.error(err)
         res2.destroy()

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -396,7 +396,7 @@ test('pipeline abort duplex', (t) => {
         t.ok(err instanceof errors.RequestAbortedError)
       })
 
-      client.on('reconnect', () => {
+      client.on('disconnect', () => {
         t.pass()
       })
     })

--- a/test/client-reconnect.js
+++ b/test/client-reconnect.js
@@ -25,7 +25,7 @@ test('multiple reconnect', (t) => {
   })
 
   let n = 0
-  client.on('reconnect', () => {
+  client.on('disconnect', () => {
     if (n++ === 1) {
       t.pass()
       server.listen(5555)

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -186,7 +186,7 @@ test('stream GET remote destroy', (t) => {
 })
 
 test('stream response resume back pressure and non standard error', (t) => {
-  t.plan(4)
+  t.plan(5)
 
   const server = createServer((req, res) => {
     res.write(Buffer.alloc(1e3))
@@ -217,7 +217,8 @@ test('stream response resume back pressure and non standard error', (t) => {
       t.ok(err)
     })
 
-    client.on('reconnect', () => {
+    client.on('disconnect', (err) => {
+      t.ok(err)
       t.pass()
     })
 


### PR DESCRIPTION
Rename reconnect to disconnect. We won't actually reconnect
unless there are pending requests. Hence, reconnect is not
strictly true.

Also forward the error which caused the socket to close in
order to provide some form of hint to the user.