### PR TITLE
fix: 100 response should not corrupt client state

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -71,6 +71,11 @@ class Parser extends HTTPParser {
     assert(!this.read)
     assert(!this.body)
 
+    if (statusCode < 200) {
+      // TODO: Informational response.
+      return true
+    }
+
     let body = request.invoke(null, {
       statusCode,
       headers: parseHeaders(headers),

--- a/test/http-100.js
+++ b/test/http-100.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { test } = require('tap')
+const { Client } = require('..')
+const { createServer } = require('http')
+
+test('ignore informational response', (t) => {
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    req.pipe(res)
+  })
+  t.teardown(server.close.bind(server))
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.teardown(client.destroy.bind(client))
+
+    client.request({
+      path: '/',
+      method: 'POST',
+      headers: {
+        Expect: '100-continue'
+      },
+      body: 'hello'
+    }, (err, response) => {
+      t.error(err)
+      const bufs = []
+      response.body.on('data', (buf) => {
+        bufs.push(buf)
+      })
+      response.body.on('end', () => {
+        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      })
+    })
+  })
+})


### PR DESCRIPTION
Even if we don't support 1xx response we shoudl still
not corrupt the client state if the server sends one.
