### PR TITLE
max connection duration proof-of-concept

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -37,7 +37,10 @@ const {
   kParser,
   kSocket,
   kEnqueue,
-  kClient
+  kClient,
+  kMaxConnectionDuration,
+  kConnectionDurationTimer,
+  kNeedsNewConnection
 } = require('./symbols')
 
 const CRLF = Buffer.from('\r\n', 'ascii')
@@ -52,6 +55,7 @@ class ClientBase extends EventEmitter {
     maxAbortedPayload,
     socketTimeout,
     requestTimeout,
+    maxConnectionDuration,
     pipelining,
     tls
   } = {}) {
@@ -93,6 +97,10 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid requestTimeout')
     }
 
+    if (maxConnectionDuration != null && !(Number.isFinite(maxConnectionDuration) || maxConnectionDuration <= 0)) {
+      throw new InvalidArgumentError('invalid maxConnectionDuration')
+    }
+
     this[kSocket] = null
     this[kPipelining] = pipelining || 1
     this[kUrl] = url
@@ -107,6 +115,9 @@ class ClientBase extends EventEmitter {
     this[kOnDestroyed] = []
     this[kWriting] = false
     this[kMaxAbortedPayload] = maxAbortedPayload || 1e6
+    this[kMaxConnectionDuration] = maxConnectionDuration
+    this[kNeedsNewConnection] = false
+    this[kConnectionDurationTimer] = null
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -251,6 +262,8 @@ class ClientBase extends EventEmitter {
 
     clearTimeout(this[kRetryTimeout])
     this[kRetryTimeout] = null
+    clearTimeout(this[kConnectionDurationTimer])
+    this[kConnectionDurationTimer] = null
     this[kClosed] = true
     this[kDestroyed] = true
     this[kOnDestroyed].push(callback)
@@ -424,6 +437,15 @@ class Parser extends HTTPParser {
   }
 }
 
+function needsNewConnection (client) {
+  if (!client.connected) {
+    return
+  }
+
+  client[kNeedsNewConnection] = true
+  client[kConnectionDurationTimer] = null
+}
+
 function connect (client) {
   assert(!client[kSocket])
   assert(!client[kRetryTimeout])
@@ -434,6 +456,7 @@ function connect (client) {
     : net.connect(port || /* istanbul ignore next */ 80, hostname)
 
   client[kSocket] = socket
+  client[kNeedsNewConnection] = false
 
   socket[kClient] = client
   socket[kParser] = new Parser(client, socket)
@@ -445,6 +468,10 @@ function connect (client) {
   socket
     .on('connect', function () {
       const client = this[kClient]
+
+      if (client[kMaxConnectionDuration] != null) {
+        client[kConnectionDurationTimer] = setTimeout(needsNewConnection, client[kMaxConnectionDuration], client).unref()
+      }
 
       client[kRetryDelay] = 0
       client.emit('connect')
@@ -580,6 +607,13 @@ function resume (client) {
       // request body fails, the client waits for inflight
       // before resetting the connection.
       return
+    }
+
+    if (client[kNeedsNewConnection]) {
+      if (client.running) return
+
+      client[kSocket].destroy()
+      connect(client)
     }
 
     client[kPendingIdx]++

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -14,6 +14,7 @@ class Pool {
     maxAbortedPayload,
     socketTimeout,
     requestTimeout,
+    maxConnectionDuration,
     pipelining,
     tls
   } = {}) {
@@ -27,6 +28,7 @@ class Pool {
       maxAbortedPayload,
       socketTimeout,
       requestTimeout,
+      maxConnectionDuration,
       pipelining,
       tls
     }))

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -21,5 +21,8 @@ module.exports = {
   kRetryTimeout: Symbol('retry timeout'),
   kClient: Symbol('client'),
   kEnqueue: Symbol('enqueue'),
-  kMaxAbortedPayload: Symbol('max aborted payload')
+  kMaxAbortedPayload: Symbol('max aborted payload'),
+  kMaxConnectionDuration: Symbol('max connection duration'),
+  kNeedsNewConnection: Symbol('needs new connection'),
+  kConnectionDurationTimer: Symbol('connection duration timer')
 }


### PR DESCRIPTION
Been watching some of the recent development here. A more performant http client for use in a reverse proxy (especially with the `.stream` method) is potentially exciting and something I'll investigate using in time.

Something we do by extending the core node Http(s)Agent is to destroy the kept-alive sockets after n minutes. This is to deal with unfortunate behaviour of some servers and cloud environments that don't necessarily drop connections when "moving"/coming out of load. AWS' ElasticBeanstalk has the option for a "CNAME swap" deployment model for instance, where both environments stay running and DNS is just updated to switch between A and B.

Put together a PoC how supporting that behaviour could be implemented in undici. The real goal is just "after some timeout has passed, re-resolve the hostname"; theoretically dropping the connection if it stays the same is unnecessary (although "same" is variable for load-balanced DNS responses).

Anyway, curious if you'd be interested in supporting such a case at the client and/or pool level, and if so I can bring the PR the rest of the way - or take it in a different direction.