### PR TITLE
fix: avoid unhandled exception on early abort

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -546,14 +546,6 @@ function resume (client) {
       return
     }
 
-    if (!client.connected) {
-      return
-    }
-
-    if (client[kWriting]) {
-      return
-    }
-
     const request = client[kQueue][client[kPendingIdx]]
 
     if (!request.callback) {
@@ -561,6 +553,14 @@ function resume (client) {
       // TODO: Avoid splice one by one.
       client[kQueue].splice(client[kPendingIdx], 1)
       continue
+    }
+
+    if (!client.connected) {
+      return
+    }
+
+    if (client[kWriting]) {
+      return
     }
 
     if (!request.idempotent && client.running) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -117,6 +117,12 @@ class Request extends AsyncResource {
       ? method === 'HEAD' || method === 'GET'
       : idempotent
 
+    if (this.streaming) {
+      this.body.on('error', (err) => {
+        this.invoke(err, null)
+      })
+    }
+
     {
       // TODO (perf): Build directy into buffer instead of
       // using an intermediate string.

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -638,3 +638,27 @@ test('pipeline factory throw not unhandled', (t) => {
       .end()
   })
 })
+
+test('pipeline destroy before dispatch', (t) => {
+  t.plan(1)
+
+  const server = createServer((req, res) => {
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client
+      .pipeline({ path: '/', method: 'GET' }, ({ body }) => {
+        return body
+      })
+      .on('error', (err) => {
+        t.ok(err)
+      })
+      .end()
+      .destroy()
+  })
+})


### PR DESCRIPTION
- Early abort of body could cause unhandled exception.
- Abort could deadlock close.