### PR TITLE
fix: pipeline destroy async scope

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -184,18 +184,23 @@ class ClientBase extends EventEmitter {
       opts = { ...opts, requestTimeout: this[kRequestTimeout] }
     }
 
+    let request
     try {
-      this[kQueue].push(new Request(opts, callback))
+      request = new Request(opts, callback)
     } catch (err) {
       process.nextTick(callback, err, null)
       return
     }
+
+    this[kQueue].push(request)
 
     if (!this[kSocket] && !this[kRetryTimeout]) {
       connect(this)
     }
 
     resume(this)
+
+    return request
   }
 
   close (callback) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -161,7 +161,7 @@ class Client extends ClientBase {
     // TODO: Avoid copy.
     opts = { ...opts, body: req }
 
-    this[kEnqueue](opts, function (err, data) {
+    const request = this[kEnqueue](opts, function (err, data) {
       if (err) {
         if (!ret.destroyed) {
           ret.destroy(err)
@@ -193,9 +193,6 @@ class Client extends ClientBase {
         }
       })
       res.destroy = this.wrap(res, res.destroy)
-
-      // TODO: Should this somehow be wrapped earlier?
-      ret.destroy = this.wrap(ret, ret.destroy)
 
       try {
         body = handler({
@@ -255,6 +252,8 @@ class Client extends ClientBase {
         }
       })
     })
+
+    ret.destroy = request.wrap(ret, ret.destroy)
 
     return ret
   }

--- a/test/async_hooks.js
+++ b/test/async_hooks.js
@@ -6,6 +6,7 @@ const { createServer } = require('http')
 const { createHook, executionAsyncId } = require('async_hooks')
 const { readFile } = require('fs')
 const { PassThrough } = require('stream')
+const { AsyncResource } = require('async_hooks')
 
 const transactions = new Map()
 
@@ -220,5 +221,39 @@ test('async hooks error and close', (t) => {
         })
       })
     })
+  })
+})
+
+test('async hooks pipeline close', (t) => {
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    setCurrentTransaction({ hello: 'world2' })
+
+    const ret = client
+      .pipeline({ path: '/', method: 'GET' }, ({ body }) => {
+        return body
+      })
+      .on('close', () => {
+        t.strictDeepEqual(getCurrentTransaction(), { hello: 'world2' })
+      })
+      .on('error', (err) => {
+        t.ok(err)
+      })
+      .end()
+
+    new AsyncResource('tmp')
+      .runInAsyncScope(() => {
+        setCurrentTransaction({ hello: 'world1' })
+        ret.destroy()
+      })
   })
 })


### PR DESCRIPTION
Ensure destroy is always in async scope.

Note, depends on and includes https://github.com/mcollina/undici/pull/213