### PR TITLE
fix: README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection.
 Keepalive is enabled by default, and it cannot be turned off.
 
 `url` can be a string or a [`URL`](https://nodejs.org/api/url.html#url_class_url) object.
-It should only include the protocol, the domain/IP address, and the port.
-
+It should only include the protocol, hostname, and the port.
 Options:
 
 - `socketTimeout`, the timeout after which a socket will time out, in

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The benchmark is a simple `hello world` [example](benchmarks/index.js).
 A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection.
 Keepalive is enabled by default, and it cannot be turned off.
 
-The `url` will be used to extract the protocol and the domain/IP
-address. The path is discarded.
+`url` can be a string or a [`URL`](https://nodejs.org/api/url.html#url_class_url) object.
+It should only include the protocol, the domain/IP address, and the port.
 
 Options:
 
@@ -289,8 +289,8 @@ The `data` parameter in `handler` is defined as follow:
   either fully consume or destroy the body unless there is an error, or no further requests
   will be processed.
 
-`handler` should return a [`Writable`](https://nodejs.org/api/stream.html#stream_class_stream_writable) to which the response will be
-written to. Usually it should just return the `body` argument unless
+`handler` should return a [`Readable`](https://nodejs.org/api/stream.html#stream_class_stream_readable) from which the result will be
+read. Usually it should just return the `body` argument unless
 some kind of transformation needs to be performed based on e.g.
 `headers` or `statusCode`.
 
@@ -324,7 +324,7 @@ stream.pipeline(
 
     return body
   }),
-  fs.createReadStream('response.raw'),
+  fs.createWriteStream('response.raw'),
   (err) => {
     if (err) {
       console.error('failed')


### PR DESCRIPTION
@ronag 

1. The description for the url parameter was misleading.
1. The description for the pipeline handler return value was wrong.
1. There was a mistake in the pipeline example.