### PR TITLE
fix: only retry recoverable socket errors

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -477,6 +477,19 @@ function connect (client) {
         while (client.pending && client[kQueue][client[kPendingIdx]].servername === servername) {
           client[kQueue][client[kPendingIdx]++].invoke(err, null)
         }
+      } else if (
+        !client.running &&
+        err.code !== 'ECONNRESET' &&
+        err.code !== 'ECONNREFUSED' &&
+        err.code !== 'EHOSTUNREACH' &&
+        err.code !== 'EHOSTDOWN' &&
+        err.code !== 'UND_ERR_SOCKET'
+      ) {
+        // Error is not caused by running request and not a recoverable
+        // socket error.
+        for (const request of client[kQueue].splice(client[kPendingIdx])) {
+          request.invoke(err, null)
+        }
       }
 
       this[kError] = err
@@ -694,6 +707,7 @@ function write (client, {
         }
 
         if (!socket.destroyed) {
+          assert(client.running)
           socket.destroy(err)
         }
       } else {


### PR DESCRIPTION
If the socket fails while there is no active request then it might not be recoverable and we should error and destroy.