### PR TITLE
Add support for unix:// connections

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -72,11 +72,11 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid hostname')
     }
 
-    if (!/https?/.test(url.protocol)) {
+    if (!/[https?|unix]/.test(url.protocol)) {
       throw new InvalidArgumentError('invalid protocol')
     }
 
-    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
+    if ((url.protocol != 'unix:' && /\/.+/.test(url.pathname)) || url.search || url.hash) {
       throw new InvalidArgumentError('invalid url')
     }
 
@@ -136,7 +136,7 @@ class ClientBase extends EventEmitter {
       this[kSocket].connecting !== true &&
       // Older versions of Node don't set secureConnecting to false.
       (this[kSocket].authorized !== false ||
-       this[kSocket].authorizationError
+        this[kSocket].authorizationError
       ) &&
       !this[kSocket].destroyed
     )
@@ -436,14 +436,22 @@ function connect (client) {
   assert(!client[kSocket])
   assert(!client[kRetryTimeout])
 
-  const { protocol, port, hostname } = client[kUrl]
+  const { protocol, port, hostname, pathname } = client[kUrl]
   const servername = client[kServerName] || (client[kTLSOpts] && client[kTLSOpts].servername)
-  const socket = protocol === 'https:'
-    ? tls.connect(port || /* istanbul ignore next */ 443, hostname, {
+
+  let socket;
+  if (protocol == 'https:') {
+    socket = tls.connect(port || /* istanbul ignore next */ 443, hostname, {
       ...client[kTLSOpts],
       servername
     })
-    : net.connect(port || /* istanbul ignore next */ 80, hostname)
+  } else if (protocol == 'http:') {
+    socket = net.connect(port || /* istanbul ignore next */ 80, hostname)
+  } else if (protocol == 'unix:') {
+    socket = net.connect(pathname)
+  } else {
+    throw new InvalidArgumentError('invalid protocol')
+  }
 
   client[kSocket] = socket
 
@@ -768,3 +776,4 @@ function parseHeaders (headers) {
 }
 
 module.exports = ClientBase
+

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -72,7 +72,7 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid hostname')
     }
 
-    if (!/^(http|https|unix):$/.test(url.protocol)) {
+    if (!/^(http|https|unix)/.test(url.protocol)) {
       throw new InvalidArgumentError('invalid protocol')
     }
 

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -72,7 +72,7 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid hostname')
     }
 
-    if (!/[https?|unix]/.test(url.protocol)) {
+    if (!/^(http|https|unix):$/.test(url.protocol)) {
       throw new InvalidArgumentError('invalid protocol')
     }
 
@@ -445,12 +445,10 @@ function connect (client) {
       ...client[kTLSOpts],
       servername
     })
-  } else if (protocol === 'http:') {
-    socket = net.connect(port || /* istanbul ignore next */ 80, hostname)
   } else if (protocol === 'unix:') {
     socket = net.connect(pathname)
   } else {
-    throw new InvalidArgumentError('invalid protocol')
+    socket = net.connect(port || /* istanbul ignore next */ 80, hostname)
   }
 
   client[kSocket] = socket

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -76,7 +76,7 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid protocol')
     }
 
-    if ((url.protocol != 'unix:' && /\/.+/.test(url.pathname)) || url.search || url.hash) {
+    if ((url.protocol !== 'unix:' && /\/.+/.test(url.pathname)) || url.search || url.hash) {
       throw new InvalidArgumentError('invalid url')
     }
 
@@ -439,15 +439,15 @@ function connect (client) {
   const { protocol, port, hostname, pathname } = client[kUrl]
   const servername = client[kServerName] || (client[kTLSOpts] && client[kTLSOpts].servername)
 
-  let socket;
-  if (protocol == 'https:') {
+  let socket
+  if (protocol === 'https:') {
     socket = tls.connect(port || /* istanbul ignore next */ 443, hostname, {
       ...client[kTLSOpts],
       servername
     })
-  } else if (protocol == 'http:') {
+  } else if (protocol === 'http:') {
     socket = net.connect(port || /* istanbul ignore next */ 80, hostname)
-  } else if (protocol == 'unix:') {
+  } else if (protocol === 'unix:') {
     socket = net.connect(pathname)
   } else {
     throw new InvalidArgumentError('invalid protocol')
@@ -776,4 +776,3 @@ function parseHeaders (headers) {
 }
 
 module.exports = ClientBase
-

--- a/lib/request.js
+++ b/lib/request.js
@@ -104,7 +104,7 @@ class Request extends AsyncResource {
       }
 
       if (!hostHeader) {
-        header += `host: ${hostname}\r\n`
+        header += `host: ${hostname || 'localhost'}\r\n`
       }
 
       header += 'connection: keep-alive\r\n'


### PR DESCRIPTION
Adds support for HTTP over `AF_UNIX` sockets (UDS) by enabling the `unix://` scheme. Most of the functionality for this exists as part of Node's `net` module, and all this patch does is ensure the connection is created the right way.

This is useful for projects that want to use HTTP as an RPC protocol, but don't want to risk exposing a TCP socket to the public. 
If this direction seems good I'd be happy to author tests for this as well.

This patch also fixes a bug where in some cases an empty `Host` header was sent which didn't seem intentional.

Overall I hope this patch is useful. Thanks heaps!

cc/ @mcollina 

## Example

```js
const { Client } = require('undici')
const client = new Client(`unix:///tmp/hello.sock`)

client.request({
    path: '/',
    method: 'GET'
}, function (err, data) {
    if (err) throw err

    const {
        statusCode,
        headers,
        body
    } = data

    console.log('response received', statusCode)
    console.log('headers', headers)

    body.setEncoding('utf8')
    body.on('data', console.log)

    client.close()
})
```