### PR TITLE
fix: use node native parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Options:
 - `tls`, an options object which in the case of `https` will be passed to
   [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
 
+- `maxHeaderSize`, the maximum length of request headers in bytes. 
+  Default: `16384` (16KiB)
+
 <a name='request'></a>
 #### `client.request(opts, callback(err, data))`
 

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -3,7 +3,8 @@
 const { URL } = require('url')
 const net = require('net')
 const tls = require('tls')
-const { HTTPParser } = require('http-parser-js')
+// TODO: This is not really allowed by Node but it works for now.
+const { HTTPParser } = process.binding('http_parser') // eslint-disable-line
 const EventEmitter = require('events')
 const Request = require('./request')
 const assert = require('assert')
@@ -37,7 +38,8 @@ const {
   kParser,
   kSocket,
   kEnqueue,
-  kClient
+  kClient,
+  kMaxHeadersSize
 } = require('./symbols')
 
 const CRLF = Buffer.from('\r\n', 'ascii')
@@ -46,9 +48,12 @@ const TE_CHUNKED_EOF = Buffer.from('\r\n0\r\n\r\n', 'ascii')
 
 function nop () {}
 
+const NODE_MAJOR_VERSION = parseInt(process.version.split('.')[0].slice(1))
+
 class ClientBase extends EventEmitter {
   constructor (url, {
     maxAbortedPayload,
+    maxHeaderSize,
     socketTimeout,
     requestTimeout,
     pipelining,
@@ -84,6 +89,10 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid maxAbortedPayload')
     }
 
+    if (maxHeaderSize != null && !Number.isFinite(maxHeaderSize)) {
+      throw new InvalidArgumentError('invalid maxHeaderSize')
+    }
+
     if (socketTimeout != null && !Number.isFinite(socketTimeout)) {
       throw new InvalidArgumentError('invalid socketTimeout')
     }
@@ -94,6 +103,7 @@ class ClientBase extends EventEmitter {
 
     this[kSocket] = null
     this[kPipelining] = pipelining || 1
+    this[kMaxHeadersSize] = maxHeaderSize || 16384
     this[kUrl] = url
     this[kSocketTimeout] = socketTimeout == null ? 30e3 : socketTimeout
     this[kRequestTimeout] = requestTimeout == null ? 30e3 : requestTimeout
@@ -287,7 +297,19 @@ class ClientBase extends EventEmitter {
 
 class Parser extends HTTPParser {
   constructor (client, socket) {
-    super(HTTPParser.RESPONSE)
+    /* istanbul ignore next */
+    if (NODE_MAJOR_VERSION >= 12) {
+      super()
+      this.initialize(
+        HTTPParser.RESPONSE,
+        {},
+        client[kMaxHeadersSize],
+        false,
+        0
+      )
+    } else {
+      super(HTTPParser.RESPONSE, false)
+    }
 
     this.client = client
     this.socket = socket
@@ -301,7 +323,8 @@ class Parser extends HTTPParser {
     // TODO: Handle trailers.
   }
 
-  [HTTPParser.kOnHeadersComplete] ({ statusCode, headers }) {
+  [HTTPParser.kOnHeadersComplete] (versionMajor, versionMinor, headers, method,
+    url, statusCode, statusMessage, upgrade, shouldKeepAlive) {
     const { client, resumeSocket } = this
     const request = client[kQueue][client[kRunningIdx]]
     const { signal, opaque } = request
@@ -427,6 +450,8 @@ class Parser extends HTTPParser {
     for (const request of errorRequests) {
       request.invoke(err, null)
     }
+
+    this.close()
   }
 }
 

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -50,6 +50,8 @@ function nop () {}
 
 const NODE_MAJOR_VERSION = parseInt(process.version.split('.')[0].slice(1))
 
+const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
+
 class ClientBase extends EventEmitter {
   constructor (url, {
     maxAbortedPayload,
@@ -304,7 +306,7 @@ class Parser extends HTTPParser {
         HTTPParser.RESPONSE,
         {},
         client[kMaxHeadersSize],
-        false,
+        insecureHTTPParser,
         0
       )
     } else {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -8,6 +8,7 @@ module.exports = {
   kTLSOpts: Symbol('TLS Options'),
   kClosed: Symbol('closed'),
   kDestroyed: Symbol('destroyed'),
+  kMaxHeadersSize: Symbol('maxHeaderSize'),
   kRunningIdx: Symbol('running index'),
   kPendingIdx: Symbol('pending index'),
   kResume: Symbol('resume'),

--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "standard": "^14.0.0",
     "tap": "^14.0.0"
   },
-  "dependencies": {
-    "http-parser-js": "^0.5.2"
-  },
   "pre-commit": [
     "coverage"
   ]

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -242,7 +242,7 @@ test('POST with chunked encoding that errors and pipelining 1 should reconnect',
 })
 
 test('invalid options throws', (t) => {
-  t.plan(24)
+  t.plan(26)
 
   try {
     new Client({ port: 'foobar' }) // eslint-disable-line
@@ -315,6 +315,15 @@ test('invalid options throws', (t) => {
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
     t.strictEqual(err.message, 'invalid hostname')
+  }
+
+  try {
+    new Client(new URL('http://localhost:200'), { // eslint-disable-line
+      maxHeaderSize: 'asd'
+    })
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.strictEqual(err.message, 'invalid maxHeaderSize')
   }
 
   try {


### PR DESCRIPTION
Using llhttp through node binding. llhttp is more maintained, secure and "correct" than http-parser-js.

@dnlup: Thanks for the hints!