### PR TITLE
feat: headers and trailers

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -13,8 +13,7 @@ const {
   RequestAbortedError,
   ClientDestroyedError,
   ClientClosedError,
-  SocketError,
-  NotSupportedError
+  SocketError
 } = require('./errors')
 const {
   kUrl,
@@ -296,9 +295,16 @@ class Parser extends HTTPParser {
     this.body = null
   }
 
-  /* istanbul ignore next: we don't support trailers yet */
-  [HTTPParser.kOnHeaders] () {
-    // TODO: Handle trailers.
+  [HTTPParser.kOnHeaders] (headers) {
+    const { client } = this
+    const request = client[kQueue][client[kRunningIdx]]
+    const { opaque } = request
+
+    request.invoke(null, {
+      type: 'trailers',
+      headers: parseHeaders(headers),
+      opaque
+    })
   }
 
   [HTTPParser.kOnHeadersComplete] ({ statusCode, headers }) {
@@ -310,17 +316,18 @@ class Parser extends HTTPParser {
     assert(!this.read)
     assert(!this.body)
 
-    if (statusCode === 101) {
-      request.invoke(new NotSupportedError('101 response not supported'))
-      return true
-    }
-
     if (statusCode < 200) {
-      // TODO: Informational response.
+      request.invoke(null, {
+        type: 'headers',
+        statusCode,
+        headers: parseHeaders(headers),
+        opaque
+      })
       return true
     }
 
     let body = request.invoke(null, {
+      type: 'body',
       statusCode,
       headers: parseHeaders(headers),
       opaque,
@@ -378,6 +385,7 @@ class Parser extends HTTPParser {
 
     resumeSocket()
 
+    client[kQueue][client[kRunningIdx]].invoke(null, null)
     client[kQueue][client[kRunningIdx]++] = null
 
     resume(client)
@@ -638,6 +646,7 @@ function resume (client) {
     // Release memory for no longer required properties.
     request.headers = null
     request.body = null
+    request.servername = null
   }
 }
 
@@ -677,7 +686,7 @@ function write (client, {
       }
     }
     const onDrain = () => {
-      // TODO (fix): Improve test coverage.
+      // TODO: Improve test coverage.
       /* istanbul ignore else */
       if (body.resume) {
         body.resume()

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,8 @@ const {
 const {
   InvalidArgumentError,
   InvalidReturnValueError,
-  RequestAbortedError
+  RequestAbortedError,
+  NotSupportedError
 } = require('./errors')
 const {
   kEnqueue,
@@ -37,12 +38,19 @@ class Client extends ClientBase {
       return
     }
 
-    // TODO: Avoid closure due to callback capture.
+    // TODO: Avoid closure due to capture.
     this[kEnqueue](opts, function (err, data) {
-      if (err) {
-        callback(err, null)
+      if (!callback) {
         return
       }
+
+      if (err) {
+        callback(err, null)
+        callback = null
+        return
+      }
+
+      assert(data)
 
       const {
         statusCode,
@@ -50,6 +58,16 @@ class Client extends ClientBase {
         opaque,
         resume
       } = data
+
+      if (statusCode === 101) {
+        callback(new NotSupportedError('101 response not supported'), null)
+        callback = null
+        return
+      }
+
+      if (!statusCode || statusCode < 200) {
+        return
+      }
 
       const body = new Readable({
         autoDestroy: true,
@@ -72,6 +90,7 @@ class Client extends ClientBase {
         opaque,
         body
       })
+      callback = null
 
       return this.wrap(body, function (err, chunk) {
         if (this.destroyed) {
@@ -162,7 +181,12 @@ class Client extends ClientBase {
     // TODO: Avoid copy.
     opts = { ...opts, body: req }
 
+    // TODO: Avoid closure due to capture.
     const request = this[kEnqueue](opts, function (err, data) {
+      if (ret.destroyed || res) {
+        return
+      }
+
       if (err) {
         if (!ret.destroyed) {
           ret.destroy(err)
@@ -170,12 +194,25 @@ class Client extends ClientBase {
         return
       }
 
+      assert(data)
+
       const {
         statusCode,
         headers,
         opaque,
         resume
       } = data
+
+      if (statusCode === 101) {
+        if (!ret.destroyed) {
+          ret.destroy(new NotSupportedError('101 response not supported'))
+        }
+        return
+      }
+
+      if (!statusCode || statusCode < 200) {
+        return
+      }
 
       res = new Readable({
         autoDestroy: true,
@@ -284,12 +321,19 @@ class Client extends ClientBase {
       return
     }
 
-    // TODO: Avoid closure due to callback capture.
+    // TODO: Avoid closure due to capture.
     this[kEnqueue](opts, function (err, data) {
-      if (err) {
-        callback(err)
+      if (!callback) {
         return
       }
+
+      if (err) {
+        callback(err, null)
+        callback = null
+        return
+      }
+
+      assert(data)
 
       const {
         statusCode,
@@ -297,6 +341,16 @@ class Client extends ClientBase {
         opaque,
         resume
       } = data
+
+      if (statusCode === 101) {
+        callback(new NotSupportedError('101 response not supported'), null)
+        callback = null
+        return
+      }
+
+      if (!statusCode || statusCode < 200) {
+        return
+      }
 
       let body
       try {
@@ -307,11 +361,13 @@ class Client extends ClientBase {
         })
       } catch (err) {
         callback(err, null)
+        callback = null
         return
       }
 
       if (!body) {
         callback(null, null)
+        callback = null
         return
       }
 
@@ -323,8 +379,12 @@ class Client extends ClientBase {
         typeof body.destroyed !== 'boolean'
       ) {
         callback(new InvalidReturnValueError('expected Writable'), null)
+        callback = null
         return
       }
+
+      const onFinished = callback
+      callback = null
 
       body.on('drain', resume)
       // TODO: Avoid finished. It registers an unecessary amount of listeners.
@@ -336,7 +396,7 @@ class Client extends ClientBase {
           }
           resume()
         }
-        callback(err, null)
+        onFinished(err, null)
       })
 
       body.destroy = this.wrap(body, body.destroy)

--- a/lib/request.js
+++ b/lib/request.js
@@ -162,21 +162,25 @@ class Request extends AsyncResource {
       return
     }
 
-    if (
-      this.body &&
-      typeof this.body.destroy === 'function' &&
-      !this.body.destroyed
-    ) {
-      this.body.destroy(err)
-    }
-
     clearTimeout(this.timeout)
     this.timeout = null
-    this.body = null
-    this.servername = null
-    this.callback = null
-    this.opaque = null
-    this.headers = null
+
+    if (!val) {
+      if (
+        this.body &&
+        typeof this.body.destroy === 'function' &&
+        !this.body.destroyed
+      ) {
+        this.body.destroy(err)
+        this.body = null
+      }
+
+      this.headers = null
+      this.body = null
+      this.servername = null
+      this.callback = null
+      this.opaque = null
+    }
 
     return this.runInAsyncScope(callback, this, err, val)
   }


### PR DESCRIPTION
Makes it possible to implement 1xx responses and trailers using the internal `kEnqueue` API (which all the public API methods are based upon). I'm considering making this API public (possibly with a better name).

Basically the internal request callback is a "stream/callbag" which is invoked multiple times:

```
callback({ type: 'headers', statusCode, headers }) // 1xx
callback({ type: 'body', statusCode, headers, body }) // body
callback({ type: 'trailers', headers }) // trailers
callback(null) // eof
```

Missing tests and actually making the API public.