### PR TITLE
feat: add support for unix socket

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -75,6 +75,10 @@ class ClientBase extends EventEmitter {
       throw new InvalidArgumentError('invalid port')
     }
 
+    if (url.socketPath != null && typeof url.socketPath !== 'string') {
+      throw new InvalidArgumentError('invalid socketPath')
+    }
+
     if (url.hostname != null && typeof url.hostname !== 'string') {
       throw new InvalidArgumentError('invalid hostname')
     }
@@ -470,14 +474,20 @@ function connect (client) {
   assert(!client[kSocket])
   assert(!client[kRetryTimeout])
 
-  const { protocol, port, hostname } = client[kUrl]
+  const { protocol, port, hostname, socketPath } = client[kUrl]
   const servername = client[kServerName] || (client[kTLSOpts] && client[kTLSOpts].servername)
-  const socket = protocol === 'https:'
-    ? tls.connect(port || /* istanbul ignore next */ 443, hostname, {
-      ...client[kTLSOpts],
-      servername
-    })
-    : net.connect(port || /* istanbul ignore next */ 80, hostname)
+
+  let socket
+  if (protocol === 'https:') {
+    const tlsOpts = { ...client[kTLSOpts], servername }
+    socket = socketPath
+      ? tls.connect(socketPath, tlsOpts)
+      : tls.connect(port || /* istanbul ignore next */ 443, hostname, tlsOpts)
+  } else {
+    socket = socketPath
+      ? net.connect(socketPath)
+      : net.connect(port || /* istanbul ignore next */ 80, hostname)
+  }
 
   client[kSocket] = socket
 

--- a/test/unix.js
+++ b/test/unix.js
@@ -1,0 +1,78 @@
+'use strict'
+
+const { test } = require('tap')
+const { Client } = require('..')
+const { createServer } = require('http')
+const pem = require('https-pem')
+
+test('http unix get', (t) => {
+  t.plan(7)
+
+  const server = createServer((req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    t.strictEqual('localhost', req.headers.host)
+    res.setHeader('Content-Type', 'text/plain')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen('/var/tmp/test3.sock', () => {
+    const client = new Client({
+      socketPath: '/var/tmp/test3.sock',
+      hostname: 'localhost',
+      protocol: 'http:'
+    })
+    t.tearDown(client.close.bind(client))
+
+    client.request({ path: '/', method: 'GET' }, (err, data) => {
+      t.error(err)
+      const { statusCode, headers, body } = data
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+      const bufs = []
+      body.on('data', (buf) => {
+        bufs.push(buf)
+      })
+      body.on('end', () => {
+        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      })
+    })
+  })
+})
+
+test('https unix get', (t) => {
+  t.plan(7)
+
+  const server = createServer(pem, (req, res) => {
+    t.strictEqual('/', req.url)
+    t.strictEqual('GET', req.method)
+    t.strictEqual('localhost', req.headers.host)
+    res.setHeader('Content-Type', 'text/plain')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen('/var/tmp/test4.sock', () => {
+    const client = new Client({
+      socketPath: '/var/tmp/test4.sock',
+      hostname: 'localhost',
+      protocol: 'http:'
+    })
+    t.tearDown(client.close.bind(client))
+
+    client.request({ path: '/', method: 'GET' }, (err, data) => {
+      t.error(err)
+      const { statusCode, headers, body } = data
+      t.strictEqual(statusCode, 200)
+      t.strictEqual(headers['content-type'], 'text/plain')
+      const bufs = []
+      body.on('data', (buf) => {
+        bufs.push(buf)
+      })
+      body.on('end', () => {
+        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      })
+    })
+  })
+})

--- a/test/unix.js
+++ b/test/unix.js
@@ -5,74 +5,76 @@ const { Client } = require('..')
 const { createServer } = require('http')
 const pem = require('https-pem')
 
-test('http unix get', (t) => {
-  t.plan(7)
+if (process.platform !== 'win32') {
+  test('http unix get', (t) => {
+    t.plan(7)
 
-  const server = createServer((req, res) => {
-    t.strictEqual('/', req.url)
-    t.strictEqual('GET', req.method)
-    t.strictEqual('localhost', req.headers.host)
-    res.setHeader('Content-Type', 'text/plain')
-    res.end('hello')
-  })
-  t.tearDown(server.close.bind(server))
-
-  server.listen('/var/tmp/test3.sock', () => {
-    const client = new Client({
-      socketPath: '/var/tmp/test3.sock',
-      hostname: 'localhost',
-      protocol: 'http:'
+    const server = createServer((req, res) => {
+      t.strictEqual('/', req.url)
+      t.strictEqual('GET', req.method)
+      t.strictEqual('localhost', req.headers.host)
+      res.setHeader('Content-Type', 'text/plain')
+      res.end('hello')
     })
-    t.tearDown(client.close.bind(client))
+    t.tearDown(server.close.bind(server))
 
-    client.request({ path: '/', method: 'GET' }, (err, data) => {
-      t.error(err)
-      const { statusCode, headers, body } = data
-      t.strictEqual(statusCode, 200)
-      t.strictEqual(headers['content-type'], 'text/plain')
-      const bufs = []
-      body.on('data', (buf) => {
-        bufs.push(buf)
+    server.listen('/var/tmp/test3.sock', () => {
+      const client = new Client({
+        socketPath: '/var/tmp/test3.sock',
+        hostname: 'localhost',
+        protocol: 'http:'
       })
-      body.on('end', () => {
-        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
-      })
-    })
-  })
-})
+      t.tearDown(client.close.bind(client))
 
-test('https unix get', (t) => {
-  t.plan(7)
-
-  const server = createServer(pem, (req, res) => {
-    t.strictEqual('/', req.url)
-    t.strictEqual('GET', req.method)
-    t.strictEqual('localhost', req.headers.host)
-    res.setHeader('Content-Type', 'text/plain')
-    res.end('hello')
-  })
-  t.tearDown(server.close.bind(server))
-
-  server.listen('/var/tmp/test4.sock', () => {
-    const client = new Client({
-      socketPath: '/var/tmp/test4.sock',
-      hostname: 'localhost',
-      protocol: 'http:'
-    })
-    t.tearDown(client.close.bind(client))
-
-    client.request({ path: '/', method: 'GET' }, (err, data) => {
-      t.error(err)
-      const { statusCode, headers, body } = data
-      t.strictEqual(statusCode, 200)
-      t.strictEqual(headers['content-type'], 'text/plain')
-      const bufs = []
-      body.on('data', (buf) => {
-        bufs.push(buf)
-      })
-      body.on('end', () => {
-        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      client.request({ path: '/', method: 'GET' }, (err, data) => {
+        t.error(err)
+        const { statusCode, headers, body } = data
+        t.strictEqual(statusCode, 200)
+        t.strictEqual(headers['content-type'], 'text/plain')
+        const bufs = []
+        body.on('data', (buf) => {
+          bufs.push(buf)
+        })
+        body.on('end', () => {
+          t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+        })
       })
     })
   })
-})
+
+  test('https unix get', (t) => {
+    t.plan(7)
+
+    const server = createServer(pem, (req, res) => {
+      t.strictEqual('/', req.url)
+      t.strictEqual('GET', req.method)
+      t.strictEqual('localhost', req.headers.host)
+      res.setHeader('Content-Type', 'text/plain')
+      res.end('hello')
+    })
+    t.tearDown(server.close.bind(server))
+
+    server.listen('/var/tmp/test4.sock', () => {
+      const client = new Client({
+        socketPath: '/var/tmp/test4.sock',
+        hostname: 'localhost',
+        protocol: 'http:'
+      })
+      t.tearDown(client.close.bind(client))
+
+      client.request({ path: '/', method: 'GET' }, (err, data) => {
+        t.error(err)
+        const { statusCode, headers, body } = data
+        t.strictEqual(statusCode, 200)
+        t.strictEqual(headers['content-type'], 'text/plain')
+        const bufs = []
+        body.on('data', (buf) => {
+          bufs.push(buf)
+        })
+        body.on('end', () => {
+          t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+        })
+      })
+    })
+  })
+}


### PR DESCRIPTION
This is the least controversial solution I could come up with. Basically just do it like Node and curl already does.

For the host header it uses the passed hostname in the url. curl does the same.