### PR TITLE
fix: pipeline with `end()` in same tick should not use chunked encoding

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -228,7 +228,7 @@ class ClientBase extends EventEmitter {
 
       this[kQueue].push(request)
 
-      resume(this)
+      process.nextTick(resume, this)
 
       return request
     } catch (err) {
@@ -312,8 +312,6 @@ class ClientBase extends EventEmitter {
         .destroy(err)
     }
 
-    // resume will invoke callbacks and must happen in nextTick
-    // TODO: Implement in a more elegant way.
     process.nextTick(resume, this)
   }
 }
@@ -609,7 +607,6 @@ function resume (client) {
     }
 
     const request = client[kQueue][client[kPendingIdx]]
-
     if (request.finished) {
       // Request was aborted.
       // TODO: Avoid splice one by one.
@@ -657,6 +654,9 @@ function resume (client) {
       // Ensure this doesn't happen by waiting for inflight
       // to complete before dispatching.
 
+      // TODO: If stream body is ended try to convert it
+      // into a buffer.
+
       // TODO: This is to strict. Would be better if when
       // request body fails, the client waits for inflight
       // before resetting the connection.
@@ -669,14 +669,12 @@ function resume (client) {
   }
 }
 
-function write (client, request) {
-  const {
-    header,
-    body,
-    streaming,
-    chunked
-  } = request
-
+function write (client, {
+  header,
+  body,
+  streaming,
+  chunked
+}) {
   let socket = client[kSocket]
 
   socket.cork()
@@ -689,6 +687,12 @@ function write (client, request) {
     socket.write(body)
     socket.write(CRLF)
   } else {
+    const state = body._readableState
+    if (chunked && state && state.ended) {
+      socket.write(`content-length: ${state.length}\r\n`, 'ascii')
+      chunked = false
+    }
+
     socket.write(chunked ? TE_CHUNKED : CRLF)
 
     const onData = (chunk) => {

--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -377,6 +377,8 @@ class Parser extends HTTPParser {
     // TODO: What if !shouldKeepAlive?
     // TODO: What if upgrade?
     // TODO: What if request.method === 'CONNECT'?
+    // TODO: What if server incorrectly provides multiple responses to same request?
+    //       Can we detect and handle it?
 
     assert(this.statusCode < 200)
 
@@ -655,7 +657,11 @@ function resume (client) {
       // to complete before dispatching.
 
       // TODO: If stream body is ended try to convert it
-      // into a buffer.
+      // into a buffer?
+
+      // TODO: If content length is known and smaller than a
+      // threshold; convert into a repeatable Stream backed
+      // by buffer?
 
       // TODO: This is to strict. Would be better if when
       // request body fails, the client waits for inflight
@@ -671,14 +677,42 @@ function resume (client) {
 
 function write (client, {
   header,
+  method,
   body,
-  streaming,
-  chunked
+  contentLength,
+  streaming
 }) {
   let socket = client[kSocket]
 
   socket.cork()
   socket.write(header)
+
+  if (contentLength === undefined) {
+    if (streaming) {
+      const state = body._readableState
+      if (state && state.ended) {
+        contentLength = state.length
+      }
+    } else {
+      contentLength = body ? Buffer.byteLength(body) : 0
+    }
+
+    if (contentLength !== undefined) {
+      // https://tools.ietf.org/html/rfc7230#section-3.3.2
+      // A user agent SHOULD NOT send a Content-Length header field when
+      // the request message does not contain a payload body and the method
+      // semantics do not anticipate such a body.
+      const methodExpectsBody = (
+        method === 'PUT' ||
+        method === 'POST' ||
+        method === 'PATCH'
+      )
+
+      if (contentLength || methodExpectsBody) {
+        socket.write(`content-length: ${contentLength}\r\n`, 'ascii')
+      }
+    }
+  }
 
   if (!body) {
     socket.write(CRLF)
@@ -687,11 +721,10 @@ function write (client, {
     socket.write(body)
     socket.write(CRLF)
   } else {
-    const state = body._readableState
-    if (chunked && state && state.ended) {
-      socket.write(`content-length: ${state.length}\r\n`, 'ascii')
-      chunked = false
-    }
+    const chunked = contentLength == null
+
+    // TODO: Error if chunked and method is GET or HEAD. Some servers will
+    // start parsing chunked data as the next request.
 
     socket.write(chunked ? TE_CHUNKED : CRLF)
 
@@ -701,7 +734,7 @@ function write (client, {
       }
 
       // TODO: If body.pause doesn't exists or doesn't stop 'data' events, it might cause
-      // excessive memory usage.
+      // excessive memory usage. Add some kind of limiter to avoid out of memory.
 
       if (socket && !socket.write(chunk) && body.pause) {
         body.pause()

--- a/lib/request.js
+++ b/lib/request.js
@@ -83,7 +83,7 @@ class Request extends AsyncResource {
       ? method === 'HEAD' || method === 'GET'
       : idempotent
 
-    this.contentLength = headers ? headers['content-length'] : undefined
+    this.contentLength = undefined
 
     if (this.streaming) {
       this.body.on('error', (err) => {
@@ -100,8 +100,16 @@ class Request extends AsyncResource {
       if (headers) {
         const headerNames = Object.keys(headers)
         for (let i = 0; i < headerNames.length; i++) {
-          const name = headerNames[i]
-          header += name + ': ' + headers[name] + '\r\n'
+          const key = headerNames[i]
+          const val = headers[key]
+          header += key + ': ' + val + '\r\n'
+
+          if (!this.contentLength && key.toLowerCase() === 'content-length') {
+            this.contentLength = val
+          }
+
+          // TODO: Check for unexpected headers that might interfere
+          // with undici assumptions, e.g. transfer-encoding?
         }
       }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -111,6 +111,7 @@ class Request extends AsyncResource {
 
       if (!headers || headers['content-length'] === undefined) {
         if (this.streaming) {
+          // TODO: Check body._readableState.ended
           this.chunked = true
         } else {
           header += `content-length: ${this.body ? Buffer.byteLength(this.body) : 0}\r\n`

--- a/lib/request.js
+++ b/lib/request.js
@@ -83,6 +83,8 @@ class Request extends AsyncResource {
       ? method === 'HEAD' || method === 'GET'
       : idempotent
 
+    this.contentLength = headers ? headers['content-length'] : undefined
+
     if (this.streaming) {
       this.body.on('error', (err) => {
         this.error(err)
@@ -108,15 +110,6 @@ class Request extends AsyncResource {
       }
 
       header += 'connection: keep-alive\r\n'
-
-      if (!headers || headers['content-length'] === undefined) {
-        if (this.streaming) {
-          // TODO: Check body._readableState.ended
-          this.chunked = true
-        } else {
-          header += `content-length: ${this.body ? Buffer.byteLength(this.body) : 0}\r\n`
-        }
-      }
 
       this.header = Buffer.from(header, 'ascii')
     }

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -14,11 +14,13 @@ const {
 test('pipeline get', (t) => {
   t.plan(14)
 
+  let count = 0
+
   const server = createServer((req, res) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
     t.strictEqual('localhost', req.headers.host)
-    t.strictEqual('0', req.headers['content-length'])
+    t.strictEqual(count++ === 0 ? '3' : undefined, req.headers['content-length'])
     res.setHeader('Content-Type', 'text/plain')
     res.end('hello')
   })
@@ -35,7 +37,7 @@ test('pipeline get', (t) => {
         t.strictEqual(headers['content-type'], 'text/plain')
         return body
       })
-        .end()
+        .end('asd')
         .on('data', (buf) => {
           bufs.push(buf)
         })

--- a/test/client-pipeline.js
+++ b/test/client-pipeline.js
@@ -18,8 +18,7 @@ test('pipeline get', (t) => {
     t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
     t.strictEqual('localhost', req.headers.host)
-    // t.strictEqual('0', req.headers['content-length'])
-    t.strictEqual(undefined, req.headers['content-length']) // TODO: Known issue.
+    t.strictEqual('0', req.headers['content-length'])
     res.setHeader('Content-Type', 'text/plain')
     res.end('hello')
   })
@@ -465,7 +464,7 @@ test('pipeline abort server res', (t) => {
 })
 
 test('pipeline abort duplex', (t) => {
-  t.plan(3)
+  t.plan(2)
 
   const server = createServer((req, res) => {
     res.end()
@@ -493,7 +492,7 @@ test('pipeline abort duplex', (t) => {
       })
 
       client.on('disconnect', () => {
-        t.pass()
+        t.fail()
       })
     })
   })

--- a/test/client.js
+++ b/test/client.js
@@ -763,6 +763,8 @@ test('non recoverable socket error fails pending request', (t) => {
     client.request({ path: '/', method: 'GET' }, (err, data) => {
       t.strictEqual(err.message, 'kaboom')
     })
-    client[kSocket].destroy(new Error('kaboom'))
+    client.on('connect', () => {
+      client[kSocket].destroy(new Error('kaboom'))
+    })
   })
 })


### PR DESCRIPTION
Fixes: https://github.com/mcollina/undici/issues/248