### PR TITLE
refactor: split impl into apis

### DIFF
--- a/lib/client-base.js
+++ b/lib/client-base.js
@@ -666,7 +666,7 @@ function resume (client) {
     }
 
     const request = client[kQueue][client[kPendingIdx]]
-    if (request.finished) {
+    if (request.aborted) {
       // Request was aborted.
       // TODO: Avoid splice one by one.
       client[kQueue].splice(client[kPendingIdx], 1)

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -1,0 +1,293 @@
+'use strict'
+
+const {
+  Readable,
+  Duplex
+} = require('stream')
+const {
+  InvalidArgumentError,
+  InvalidReturnValueError,
+  RequestAbortedError,
+  RequestTimeoutError
+} = require('./errors')
+const { kResume, kRequestTimeout } = require('./symbols')
+const Request = require('./request')
+const util = require('./util')
+const assert = require('assert')
+
+// TODO: Refactor
+
+class PipelineRequest extends Request {
+  constructor ({ requestTimeout, ...opts }, callback) {
+    super(opts)
+
+    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
+      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
+    }
+
+    this.timeout = requestTimeout
+      ? setTimeout((self) => {
+        self.onError(new RequestTimeoutError())
+      }, requestTimeout, this)
+      : null
+    this.callback = callback
+    this.aborted = false
+  }
+
+  onHeaders (statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // TODO: Informational response.
+      return
+    }
+
+    if (this.aborted) {
+      return
+    }
+    this.aborted = true
+
+    clearTimeout(this.timeout)
+    this.timeout = null
+
+    this.res = this.callback(null, {
+      statusCode,
+      headers,
+      opaque: this.opaque,
+      resume
+    })
+  }
+
+  onBody (chunk, offset, length) {
+    if (this.res) {
+      return this.res(null, chunk.slice(offset, offset + length))
+    }
+  }
+
+  onComplete (trailers) {
+    // TODO: Trailers?
+
+    if (this.res) {
+      const res = this.res
+      this.res = null
+      res(null, null)
+    }
+  }
+
+  onError (err) {
+    if (util.isStream(this.body)) {
+      // TODO: If this.body.destroy doesn't exists or doesn't emit 'error' or
+      // 'close', it can halt execution in client.
+      const body = this.body
+      this.body = null
+      util.destroy(body, err)
+    }
+
+    if (this.res) {
+      const res = this.res
+      this.res = null
+      res(err, null)
+    }
+
+    if (this.aborted) {
+      return
+    }
+    this.aborted = true
+
+    clearTimeout(this.timeout)
+    this.timeout = null
+
+    this.callback(err, null)
+  }
+}
+
+module.exports = function (client, opts, handler) {
+  if (opts.requestTimeout == null && client[kRequestTimeout]) {
+    // TODO: Avoid copy.
+    opts = { ...opts, requestTimeout: client[kRequestTimeout] }
+  }
+
+  const req = new Readable({
+    autoDestroy: true,
+    read () {
+      if (this[kResume]) {
+        const resume = this[kResume]
+        this[kResume] = null
+        resume()
+      }
+    },
+    destroy (err, callback) {
+      if (err) {
+        if (this[kResume]) {
+          const resume = this[kResume]
+          this[kResume] = null
+          resume(err)
+        } else {
+          // Stop ret from scheduling more writes.
+          util.destroy(ret, err)
+        }
+      } else {
+        if (!this._readableState.endEmitted) {
+          // This can happen if the server doesn't care
+          // about the entire request body.
+          // TODO: Is this fine to ignore?
+        }
+      }
+
+      if (request) {
+        request.runInAsyncScope(
+          callback,
+          null,
+          err,
+          null
+        )
+      } else {
+        callback(err, null)
+      }
+    }
+  }).on('error', util.nop)
+
+  let res
+  let body
+
+  const ret = new Duplex({
+    readableObjectMode: opts.objectMode,
+    autoDestroy: true,
+    read () {
+      if (body && body.resume) {
+        body.resume()
+      }
+    },
+    write (chunk, encoding, callback) {
+      assert(!req.destroyed)
+      if (req.push(chunk, encoding)) {
+        callback()
+      } else {
+        req[kResume] = callback
+      }
+    },
+    destroy (err, callback) {
+      if (!err && !this._readableState.endEmitted) {
+        err = new RequestAbortedError()
+      }
+      util.destroy(body, err)
+      util.destroy(req, err)
+      util.destroy(res, err)
+      if (request) {
+        request.runInAsyncScope(
+          callback,
+          null,
+          err,
+          null
+        )
+      } else {
+        callback(err, null)
+      }
+    }
+  }).on('prefinish', () => {
+    // Node < 15 does not call _final in same tick.
+    req.push(null)
+    client[kResume]()
+  })
+
+  // TODO: Avoid copy.
+  opts = { ...opts, body: req }
+
+  const request = new PipelineRequest(opts, function (err, data) {
+    if (err) {
+      util.destroy(ret, err)
+      return
+    }
+
+    const {
+      statusCode,
+      headers,
+      opaque,
+      resume
+    } = data
+
+    const request = this
+    res = new Readable({
+      autoDestroy: true,
+      read: resume,
+      destroy (err, callback) {
+        resume()
+
+        if (!err && !this._readableState.endEmitted) {
+          err = new RequestAbortedError()
+        }
+
+        if (err) {
+          util.destroy(ret, err)
+        }
+
+        request.runInAsyncScope(
+          callback,
+          null,
+          err,
+          null
+        )
+      }
+    })
+
+    try {
+      body = handler({
+        statusCode,
+        headers,
+        opaque,
+        body: res
+      })
+    } catch (err) {
+      res.on('error', util.nop)
+      util.destroy(ret, err)
+      return
+    }
+
+    // TODO: Should we allow !body?
+    if (!body || typeof body.on !== 'function') {
+      util.destroy(ret, new InvalidReturnValueError('expected Readable'))
+      return
+    }
+
+    // TODO: If body === res then avoid intermediate
+    // and write directly to ret.push? Or should this
+    // happen when body is null?
+
+    let ended = false
+    body
+      .on('data', function (chunk) {
+        if (!ret.push(chunk) && this.pause) {
+          this.pause()
+        }
+      })
+      .on('error', function (err) {
+        util.destroy(ret, err)
+      })
+      .on('end', function () {
+        ended = true
+        ret.push(null)
+      })
+      .on('close', function () {
+        if (!ended) {
+          util.destroy(ret, new RequestAbortedError())
+        }
+      })
+
+    if (typeof body.destroy === 'function') {
+      body.destroy = this.runInAsyncScope.bind(this, body.destroy, body)
+    }
+
+    return function (err, chunk) {
+      if (res.destroyed) {
+        return null
+      } else if (err) {
+        res.destroy(err)
+      } else {
+        const ret = res.push(chunk)
+        return res.destroyed ? null : ret
+      }
+    }
+  })
+
+  request.ret = ret
+
+  return request
+}

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const { Readable } = require('stream')
+const Request = require('./request')
+const {
+  InvalidArgumentError,
+  RequestTimeoutError,
+  RequestAbortedError
+} = require('./errors')
+const util = require('./util')
+const { kRequestTimeout } = require('./symbols')
+
+class RequestRequest extends Request {
+  constructor (client, opts, callback) {
+    super(opts)
+
+    const requestTimeout = opts.requestTimeout == null && client[kRequestTimeout]
+      ? client[kRequestTimeout]
+      : opts.requestTimeout
+
+    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
+      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
+    }
+
+    this.timeout = requestTimeout
+      ? setTimeout((self) => {
+        self.onError(new RequestTimeoutError())
+      }, requestTimeout, this)
+      : null
+
+    this.aborted = false
+    this.callback = callback
+    this.res = null
+  }
+
+  onHeaders (statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // TODO: Informational response.
+      return
+    }
+
+    if (!this.callback) {
+      return
+    }
+
+    const { callback, opaque } = this
+    this.callback = null
+
+    clearTimeout(this.timeout)
+
+    const request = this
+    this.res = new Readable({
+      autoDestroy: true,
+      read: resume,
+      destroy (err, callback) {
+        resume()
+
+        if (!err && !this._readableState.endEmitted) {
+          err = new RequestAbortedError()
+        }
+
+        request.runInAsyncScope(
+          callback,
+          null,
+          err,
+          null
+        )
+      }
+    })
+
+    callback(null, {
+      statusCode,
+      headers,
+      opaque,
+      body: this.res
+    })
+  }
+
+  onBody (chunk, offset, length) {
+    if (this.aborted || !this.res || util.isDestroyed(this.res)) {
+      return null
+    }
+    const ret = this.res.push(chunk.slice(offset, offset + length))
+    return util.isDestroyed(this.res) ? null : ret
+  }
+
+  onComplete (trailers) {
+    if (this.aborted || !this.res || util.isDestroyed(this.res)) {
+      return
+    }
+
+    // TODO: Trailers?
+
+    this.res.push(null)
+  }
+
+  onError (err) {
+    if (this.aborted) {
+      return
+    }
+    this.aborted = true
+
+    util.destroy(this.body, err)
+    util.destroy(this.res, err)
+
+    clearTimeout(this.timeout)
+
+    if (this.callback) {
+      process.nextTick(this.callback, err, null)
+    }
+  }
+}
+
+module.exports = function (client, opts, callback) {
+  return new RequestRequest(client, opts, callback)
+}

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -1,0 +1,135 @@
+'use strict'
+
+const { finished } = require('stream')
+const Request = require('./request')
+const {
+  InvalidArgumentError,
+  InvalidReturnValueError,
+  RequestTimeoutError
+} = require('./errors')
+const util = require('./util')
+const { kRequestTimeout } = require('./symbols')
+
+class StreamRequest extends Request {
+  constructor (client, opts, factory, callback) {
+    super(opts)
+
+    const requestTimeout = opts.requestTimeout == null && client[kRequestTimeout]
+      ? client[kRequestTimeout]
+      : opts.requestTimeout
+
+    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
+      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
+    }
+
+    this.timeout = requestTimeout
+      ? setTimeout((self) => {
+        self.onError(new RequestTimeoutError())
+      }, requestTimeout, this)
+      : null
+
+    this.aborted = false
+    this.factory = factory
+    this.callback = callback
+    this.res = null
+  }
+
+  onHeaders (statusCode, headers, resume) {
+    if (statusCode < 200) {
+      // TODO: Informational response.
+      return
+    }
+
+    if (!this.callback) {
+      return
+    }
+
+    const { callback, factory, opaque } = this
+    this.callback = null
+
+    clearTimeout(this.timeout)
+
+    let res
+    try {
+      res = factory({
+        statusCode,
+        headers,
+        opaque
+      })
+    } catch (err) {
+      callback(err, null)
+      return
+    }
+
+    if (!res) {
+      callback(null, null)
+      return
+    }
+
+    if (
+      typeof res.write !== 'function' ||
+      typeof res.end !== 'function' ||
+      typeof res.on !== 'function'
+    ) {
+      callback(new InvalidReturnValueError('expected Writable'), null)
+      return
+    }
+
+    res.on('drain', resume)
+    // TODO: Avoid finished. It registers an unecessary amount of listeners.
+    finished(res, { readable: false }, (err) => {
+      res.removeListener('drain', resume)
+      resume()
+
+      if (err || !res.readable) {
+        util.destroy(res, err)
+      }
+
+      callback(err, null)
+    })
+
+    if (typeof res.destroy === 'function') {
+      res.destroy = this.runInAsyncScope.bind(this, res.destroy, res)
+    }
+
+    this.res = res
+  }
+
+  onBody (chunk, offset, length) {
+    if (this.aborted || !this.res || util.isDestroyed(this.res)) {
+      return null
+    }
+    const ret = this.res.write(chunk.slice(offset, offset + length))
+    return util.isDestroyed(this.res) ? null : ret
+  }
+
+  onComplete (trailers) {
+    if (this.aborted || !this.res || util.isDestroyed(this.res)) {
+      return
+    }
+
+    // TODO: Trailers?
+
+    this.res.end()
+  }
+
+  onError (err) {
+    if (this.aborted) {
+      return
+    }
+    this.aborted = true
+
+    util.destroy(this.body, err)
+    util.destroy(this.res, err)
+
+    clearTimeout(this.timeout)
+
+    if (this.callback) {
+      process.nextTick(this.callback, err, null)
+    }
+  }
+}
+
+module.exports = function (client, opts, factory, handler) {
+  return new StreamRequest(client, opts, factory, handler)
+}

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,113 +1,20 @@
-const {
-  Readable,
-  Duplex,
-  PassThrough,
-  finished
-} = require('stream')
+'use strict'
+
+const { PassThrough } = require('stream')
 const {
   InvalidArgumentError,
-  InvalidReturnValueError,
-  RequestAbortedError,
   ClientClosedError,
-  ClientDestroyedError,
-  RequestTimeoutError
+  ClientDestroyedError
 } = require('./errors')
-const Request = require('./request')
 const {
   kEnqueue,
-  kRequestTimeout,
-  kResume,
   kDestroyed,
   kClosed
 } = require('./symbols')
 const ClientBase = require('./client-base')
-const assert = require('assert')
-const util = require('./util')
-
-class BasicRequest extends Request {
-  constructor ({ requestTimeout, ...opts }, callback) {
-    super(opts)
-
-    assert(typeof callback === 'function')
-
-    if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
-      throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
-    }
-
-    this.timeout = requestTimeout
-      ? setTimeout((self) => {
-        self.onError(new RequestTimeoutError())
-      }, requestTimeout, this)
-      : null
-    this.callback = callback
-    this.finished = false
-  }
-
-  onHeaders (statusCode, headers, resume) {
-    if (statusCode < 200) {
-      // TODO: Informational response.
-      return
-    }
-
-    if (this.finished) {
-      return
-    }
-    this.finished = true
-
-    clearTimeout(this.timeout)
-    this.timeout = null
-
-    this.res = this.callback(null, {
-      statusCode,
-      headers,
-      opaque: this.opaque,
-      resume
-    })
-    assert(!this.res || typeof this.res === 'function')
-  }
-
-  onBody (chunk, offset, length) {
-    if (this.res) {
-      return this.res(null, chunk.slice(offset, offset + length))
-    }
-  }
-
-  onComplete (trailers) {
-    // TODO: Trailers?
-
-    if (this.res) {
-      const res = this.res
-      this.res = null
-      res(null, null)
-    }
-  }
-
-  onError (err) {
-    if (util.isStream(this.body)) {
-      // TODO: If this.body.destroy doesn't exists or doesn't emit 'error' or
-      // 'close', it can halt execution in client.
-      const body = this.body
-      this.body = null
-      util.destroy(body, err)
-    }
-
-    if (this.res) {
-      const res = this.res
-      this.res = null
-      res(err, null)
-    }
-
-    if (this.finished) {
-      return
-    }
-    this.finished = true
-
-    clearTimeout(this.timeout)
-    this.timeout = null
-
-    this.callback(err, null)
-  }
-}
+const makeStream = require('./client-stream')
+const makeRequest = require('./client-request')
+const makePipeline = require('./client-pipeline')
 
 class Client extends ClientBase {
   request (opts, callback) {
@@ -136,277 +43,9 @@ class Client extends ClientBase {
         throw new ClientClosedError()
       }
 
-      if (opts.requestTimeout == null && this[kRequestTimeout]) {
-        // TODO: Avoid copy.
-        opts = { ...opts, requestTimeout: this[kRequestTimeout] }
-      }
-
-      this[kEnqueue](new BasicRequest(opts, function (err, data) {
-        if (err) {
-          process.nextTick(callback, err, null)
-          return
-        }
-
-        const {
-          statusCode,
-          headers,
-          opaque,
-          resume
-        } = data
-
-        const request = this
-        const body = new Readable({
-          autoDestroy: true,
-          read: resume,
-          destroy (err, callback) {
-            resume()
-
-            if (!err && !this._readableState.endEmitted) {
-              err = new RequestAbortedError()
-            }
-
-            request.runInAsyncScope(
-              callback,
-              null,
-              err,
-              null
-            )
-          }
-        })
-
-        callback(null, {
-          statusCode,
-          headers,
-          opaque,
-          body
-        })
-
-        return function (err, chunk) {
-          if (body.destroyed) {
-            return null
-          } else if (err) {
-            body.destroy(err)
-          } else {
-            const ret = body.push(chunk)
-            return body.destroyed ? null : ret
-          }
-        }
-      }))
+      this[kEnqueue](makeRequest(this, opts, callback))
     } catch (err) {
       process.nextTick(callback, err, null)
-    }
-  }
-
-  pipeline (opts, handler) {
-    try {
-      if (!opts || typeof opts !== 'object') {
-        throw new InvalidArgumentError('invalid opts')
-      }
-
-      if (typeof handler !== 'function') {
-        throw new InvalidArgumentError('invalid handler')
-      }
-
-      if (this[kDestroyed]) {
-        throw new ClientDestroyedError()
-      }
-
-      if (this[kClosed]) {
-        throw new ClientClosedError()
-      }
-
-      const req = new Readable({
-        autoDestroy: true,
-        read () {
-          if (this[kResume]) {
-            const resume = this[kResume]
-            this[kResume] = null
-            resume()
-          }
-        },
-        destroy (err, callback) {
-          if (err) {
-            if (this[kResume]) {
-              const resume = this[kResume]
-              this[kResume] = null
-              resume(err)
-            } else {
-              // Stop ret from scheduling more writes.
-              util.destroy(ret, err)
-            }
-          } else {
-            if (!this._readableState.endEmitted) {
-              // This can happen if the server doesn't care
-              // about the entire request body.
-              // TODO: Is this fine to ignore?
-            }
-          }
-
-          if (request) {
-            request.runInAsyncScope(
-              callback,
-              null,
-              err,
-              null
-            )
-          } else {
-            callback(err, null)
-          }
-        }
-      }).on('error', util.nop)
-
-      let res
-      let body
-
-      const ret = new Duplex({
-        readableObjectMode: opts.objectMode,
-        autoDestroy: true,
-        read () {
-          if (body && body.resume) {
-            body.resume()
-          }
-        },
-        write (chunk, encoding, callback) {
-          assert(!req.destroyed)
-          if (req.push(chunk, encoding)) {
-            callback()
-          } else {
-            req[kResume] = callback
-          }
-        },
-        destroy (err, callback) {
-          if (!err && !this._readableState.endEmitted) {
-            err = new RequestAbortedError()
-          }
-          util.destroy(body, err)
-          util.destroy(req, err)
-          util.destroy(res, err)
-          if (request) {
-            request.runInAsyncScope(
-              callback,
-              null,
-              err,
-              null
-            )
-          } else {
-            callback(err, null)
-          }
-        }
-      }).on('prefinish', () => {
-        // Node < 15 does not call _final in same tick.
-        req.push(null)
-        this[kResume]()
-      })
-
-      // TODO: Avoid copy.
-      opts = { ...opts, body: req }
-
-      if (opts.requestTimeout == null && this[kRequestTimeout]) {
-        // TODO: Avoid copy.
-        opts = { ...opts, requestTimeout: this[kRequestTimeout] }
-      }
-
-      const request = new BasicRequest(opts, function (err, data) {
-        if (err) {
-          util.destroy(ret, err)
-          return
-        }
-
-        const {
-          statusCode,
-          headers,
-          opaque,
-          resume
-        } = data
-
-        const request = this
-        res = new Readable({
-          autoDestroy: true,
-          read: resume,
-          destroy (err, callback) {
-            resume()
-
-            if (!err && !this._readableState.endEmitted) {
-              err = new RequestAbortedError()
-            }
-
-            if (err) {
-              util.destroy(ret, err)
-            }
-
-            request.runInAsyncScope(
-              callback,
-              null,
-              err,
-              null
-            )
-          }
-        })
-
-        try {
-          body = handler({
-            statusCode,
-            headers,
-            opaque,
-            body: res
-          })
-        } catch (err) {
-          res.on('error', util.nop)
-          util.destroy(ret, err)
-          return
-        }
-
-        // TODO: Should we allow !body?
-        if (!body || typeof body.on !== 'function') {
-          util.destroy(ret, new InvalidReturnValueError('expected Readable'))
-          return
-        }
-
-        // TODO: If body === res then avoid intermediate
-        // and write directly to ret.push? Or should this
-        // happen when body is null?
-
-        let ended = false
-        body
-          .on('data', function (chunk) {
-            if (!ret.push(chunk) && this.pause) {
-              this.pause()
-            }
-          })
-          .on('error', function (err) {
-            util.destroy(ret, err)
-          })
-          .on('end', function () {
-            ended = true
-            ret.push(null)
-          })
-          .on('close', function () {
-            if (!ended) {
-              util.destroy(ret, new RequestAbortedError())
-            }
-          })
-
-        if (typeof body.destroy === 'function') {
-          body.destroy = this.runInAsyncScope.bind(this, body.destroy, body)
-        }
-
-        return function (err, chunk) {
-          if (res.destroyed) {
-            return null
-          } else if (err) {
-            res.destroy(err)
-          } else {
-            const ret = res.push(chunk)
-            return res.destroyed ? null : ret
-          }
-        }
-      })
-
-      this[kEnqueue](request)
-
-      return ret
-    } catch (err) {
-      return new PassThrough().destroy(err)
     }
   }
 
@@ -440,82 +79,37 @@ class Client extends ClientBase {
         throw new ClientClosedError()
       }
 
-      if (opts.requestTimeout == null && this[kRequestTimeout]) {
-        // TODO: Avoid copy.
-        opts = { ...opts, requestTimeout: this[kRequestTimeout] }
-      }
-
-      this[kEnqueue](new BasicRequest(opts, function (err, data) {
-        if (err) {
-          process.nextTick(callback, err, null)
-          return
-        }
-
-        const {
-          statusCode,
-          headers,
-          opaque,
-          resume
-        } = data
-
-        let body
-        try {
-          body = factory({
-            statusCode,
-            headers,
-            opaque
-          })
-        } catch (err) {
-          callback(err, null)
-          return
-        }
-
-        if (!body) {
-          callback(null, null)
-          return
-        }
-
-        if (
-          typeof body.write !== 'function' ||
-          typeof body.end !== 'function' ||
-          typeof body.on !== 'function'
-        ) {
-          callback(new InvalidReturnValueError('expected Writable'), null)
-          return
-        }
-
-        body.on('drain', resume)
-        // TODO: Avoid finished. It registers an unecessary amount of listeners.
-        finished(body, { readable: false }, (err) => {
-          body.removeListener('drain', resume)
-          resume()
-
-          if (err || !body.readable) {
-            util.destroy(body, err)
-          }
-
-          callback(err, null)
-        })
-
-        if (typeof body.destroy === 'function') {
-          body.destroy = this.runInAsyncScope.bind(this, body.destroy, body)
-        }
-
-        return function (err, chunk) {
-          if (util.isDestroyed(body)) {
-            return null
-          } else if (err) {
-            util.destroy(body, err)
-          } else if (chunk == null) {
-            body.end()
-          } else {
-            const ret = body.write(chunk)
-            return util.isDestroyed(body) ? null : ret
-          }
-        }
-      }))
+      this[kEnqueue](makeStream(this, opts, factory, callback))
     } catch (err) {
       process.nextTick(callback, err, null)
+    }
+  }
+
+  pipeline (opts, handler) {
+    try {
+      if (!opts || typeof opts !== 'object') {
+        throw new InvalidArgumentError('invalid opts')
+      }
+
+      if (typeof handler !== 'function') {
+        throw new InvalidArgumentError('invalid handler')
+      }
+
+      if (this[kDestroyed]) {
+        throw new ClientDestroyedError()
+      }
+
+      if (this[kClosed]) {
+        throw new ClientClosedError()
+      }
+
+      const request = makePipeline(this, opts, handler)
+
+      this[kEnqueue](request)
+
+      return request.ret
+    } catch (err) {
+      return new PassThrough().destroy(err)
     }
   }
 }

--- a/test/client.js
+++ b/test/client.js
@@ -37,7 +37,6 @@ test('basic get', (t) => {
       method: 'GET',
       headers: reqHeaders
     }, (err, data) => {
-      console.error(err)
       t.error(err)
       const { statusCode, headers, body } = data
       t.strictEqual(statusCode, 200)


### PR DESCRIPTION
This refactors the implementation a bit by moving logic out from `Request` and into the specific API implementations. This will allow future improvements to the API and extend it to support trailers, informational headers, upgrades and connect.

It does introduce some code duplication that did not exist before but I think it's worth it.

An API (`client.request`, `client.pipeline`, `client.stream`) is now expected to extend `Request` and implement the following methods:

```js
class MyApi extends Request {
  onHeaders(statusCode, headers, resume),
  onBody(chunk, offset, length),
  onComplete(trailers),
  onError(err)
}
```

Plan to add `onUpgrade` for websocket upgrades and `CONNECT` later, e.g. for `client.upgrade` and `client.connect` or something...