### PR TITLE
bench: add more variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 ```
-http - keepalive - pipe x 5,521 ops/sec ±3.37% (73 runs sampled)
-undici - pipeline - pipe x 9,292 ops/sec ±4.28% (79 runs sampled)
-undici - request - pipe x 11,949 ops/sec ±0.99% (85 runs sampled)
-undici - stream - pipe x 12,223 ops/sec ±0.76% (85 runs sampled)
+http - keepalive x 5,521 ops/sec ±3.37% (73 runs sampled)
+undici - pipeline x 9,292 ops/sec ±4.28% (79 runs sampled)
+undici - request x 11,949 ops/sec ±0.99% (85 runs sampled)
+undici - stream x 12,223 ops/sec ±0.76% (85 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -5,7 +5,8 @@ const {
   InvalidArgumentError
 } = require('./errors')
 const {
-  kClients
+  kClients,
+  kGetNext
 } = require('./symbols')
 
 class Pool {
@@ -30,6 +31,10 @@ class Pool {
       pipelining,
       tls
     }))
+  }
+
+  [kGetNext] () {
+    return getNext(this)
   }
 
   stream (opts, factory, cb) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -10,6 +10,7 @@ module.exports = {
   kTLSOpts: Symbol('TLS Options'),
   kClosed: Symbol('closed'),
   kReset: Symbol('reset'),
+  kGetNext: Symbol('getNext'),
   kDestroyed: Symbol('destroyed'),
   kMaxHeadersSize: Symbol('maxHeaderSize'),
   kHeadersTimeout: Symbol('maxHeaderSize'),


### PR DESCRIPTION
Adds some more variations to benchmark to explore what the theoretical maximum performance is.


```js
http - keepalive x 5,291 ops/sec ±5.37% (71 runs sampled)
undici - pipeline x 9,330 ops/sec ±2.53% (81 runs sampled)
undici - request x 11,724 ops/sec ±1.36% (83 runs sampled)
undici - stream x 11,988 ops/sec ±2.29% (80 runs sampled)
undici - simple x 13,391 ops/sec ±1.05% (81 runs sampled)
undici - noop x 19,939 ops/sec ±3.01% (65 runs sampled)
```

In particular it's interesting that `simple` is so much faster than `stream`. Might be interesting to explore where that overhead occurs.

`noop` is intersting to detect regression in dispatching and parsing of requests.