### PR TITLE
ci: add benchmarks jobs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,37 @@
+name: Benchmarks
+on:
+  - push
+  - pull_request
+
+jobs:
+  benchmark_current:
+    name: benchmark current
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Modules
+        run: npm i
+      - name: Run Benchmark
+        run: npm run bench
+
+  benchmark_branch:
+    name: benchmark branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Modules
+        run: npm i
+      - name: Run Benchmark
+        run: npm run bench

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "standard | snazzy",
     "test": "tap test/*.js --no-coverage",
-    "coverage": "standard | snazzy && tap test/*.js"
+    "coverage": "standard | snazzy && tap test/*.js",
+    "bench": "npx concurrently -k -s first \"node benchmarks/server.js\" \"node -e 'setTimeout(() => {}, 1000)' && node benchmarks\""
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
     "@sinonjs/fake-timers": "^6.0.1",
     "abort-controller": "^3.0.0",
     "benchmark": "^2.1.4",
+    "concurrently": "^5.2.0",
     "https-pem": "^2.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.0.1",


### PR DESCRIPTION
Add benchmarks jobs in CI workflow. It was taken from https://github.com/mcollina/undici/issues/256#issuecomment-657255734 .

Did you have some customization in mind specific for `undici`?

TODO:

- [x] add CI job
- [x] add npm job

Fix #256 