### PR TITLE
Compatibility with IncomingMessage

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,9 +2,7 @@
 
 const assert = require('assert')
 const { kDestroyed } = require('./symbols')
-
-// Use of Node.js internal :/
-const { IncomingMessage } = require('_http_incoming')
+const { IncomingMessage } = require('http')
 
 function nop () {}
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,9 @@
 const assert = require('assert')
 const { kDestroyed } = require('./symbols')
 
+// Use of Node.js internal :/
+const { IncomingMessage } = require('_http_incoming')
+
 function nop () {}
 
 function isStream (body) {
@@ -35,7 +38,9 @@ function destroy (stream, err) {
   }
 
   if (typeof stream.destroy === 'function') {
-    stream.destroy(err)
+    if (err || Object.getPrototypeOf(stream).constructor !== IncomingMessage) {
+      stream.destroy(err)
+    }
   } else if (err) {
     process.nextTick((stream, err) => {
       stream.emit('error', err)


### PR DESCRIPTION
In one of the previous changes we did lost compatibility with `IncomingMessage`, which is a feature needed to avoid parsing the bodies of requests in proxies.

I think this is the simplest fix. I know it is using `IncomingMessage` directly, but I think it's pretty safe.
We might need a similar fix for http2 compat.