### PR TITLE
Throw if connection header is specified

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -99,7 +99,7 @@ class Request extends AsyncResource {
         for (const [key, val] of Object.entries(headers)) {
           if (typeof val === 'object') {
             throw new InvalidArgumentError(`invalid ${key} header`)
-          } else if (val === undefined) {
+          } else if (val === undefined || key === 'connection') {
             continue
           }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -99,7 +99,7 @@ class Request extends AsyncResource {
         for (const [key, val] of Object.entries(headers)) {
           if (typeof val === 'object') {
             throw new InvalidArgumentError(`invalid ${key} header`)
-          } else if (val === undefined || key === 'connection') {
+          } else if (val === undefined) {
             continue
           }
 
@@ -117,6 +117,11 @@ class Request extends AsyncResource {
             key.toLowerCase() === 'transfer-encoding'
           ) {
             throw new InvalidArgumentError('invalid transfer-encoding header')
+          } else if (
+            key.length === 10 &&
+            key.toLowerCase() === 'connection'
+          ) {
+            throw new InvalidArgumentError('invalid connection header')
           } else {
             header += `${key}: ${val}\r\n`
           }

--- a/test/client.js
+++ b/test/client.js
@@ -857,31 +857,3 @@ test('non recoverable socket error fails pending request', (t) => {
     })
   })
 })
-
-test('connection header is overridden', (t) => {
-  t.plan(2)
-
-  const server = createServer((req, res) => {
-    t.strictEqual(req.headers.connection, 'keep-alive')
-    res.end('hello')
-  })
-  t.tearDown(server.close.bind(server))
-
-  const reqHeaders = {
-    connection: 'close'
-  }
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.tearDown(client.close.bind(client))
-
-    client.request({
-      path: '/',
-      method: 'GET',
-      headers: reqHeaders
-    }, (err, { body }) => {
-      t.error(err)
-      body.resume()
-    })
-  })
-})

--- a/test/client.js
+++ b/test/client.js
@@ -857,3 +857,31 @@ test('non recoverable socket error fails pending request', (t) => {
     })
   })
 })
+
+test('connection header is overridden', (t) => {
+  t.plan(2)
+
+  const server = createServer((req, res) => {
+    t.strictEqual(req.headers.connection, 'keep-alive')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  const reqHeaders = {
+    connection: 'close'
+  }
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.request({
+      path: '/',
+      method: 'GET',
+      headers: reqHeaders
+    }, (err, { body }) => {
+      t.error(err)
+      body.resume()
+    })
+  })
+})

--- a/test/http-100.js
+++ b/test/http-100.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const { Client, errors } = require('..')
+const { Client } = require('..')
 const { createServer } = require('http')
 const net = require('net')
 
@@ -32,36 +32,6 @@ test('ignore informational response', (t) => {
       response.body.on('end', () => {
         t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
       })
-    })
-  })
-})
-
-test('error 101', (t) => {
-  t.plan(2)
-
-  const server = net.createServer((socket) => {
-    socket.write('HTTP/1.1 101 Switching Protocols\r\n')
-    socket.write('Upgrade: TLS/1.0, HTTP/1.1\r\n')
-    socket.write('Connection: Upgrade\r\n')
-    socket.write('\r\n')
-  })
-  t.teardown(server.close.bind(server))
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.teardown(client.destroy.bind(client))
-
-    client.request({
-      path: '/',
-      method: 'GET',
-      headers: {
-        Connection: 'upgrade',
-        Upgrade: 'example/1, foo/2'
-      }
-    }, (err) => {
-      t.ok(err instanceof errors.NotSupportedError)
-    })
-    client.on('disconnect', () => {
-      t.pass()
     })
   })
 })

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { Client, errors } = require('..')
 
 test('invalid headers', (t) => {
-  t.plan(4)
+  t.plan(5)
 
   const client = new Client('http://localhost:3000')
   t.teardown(client.destroy.bind(client))
@@ -23,6 +23,16 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: {
       'transfer-encoding': 'chunked'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      connection: 'close'
     }
   }, (err, data) => {
     t.ok(err instanceof errors.InvalidArgumentError)


### PR DESCRIPTION
As titled. Without this patch we had a double `connection` header which was confusing some server.