### PR TITLE
fix: throw on keep-alive header

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -412,6 +412,7 @@ class Parser extends HTTPParser {
     const request = client[kQueue][client[kRunningIdx]]
 
     // TODO: Check for content-length mismatch?
+    // TODO: keep-alive timeout & max?
 
     assert(this.statusCode < 200)
 
@@ -566,16 +567,17 @@ function connect (client) {
   }
 
   socket[kError] = null
-  socket.setTimeout(client[kSocketTimeout], function () {
-    util.destroy(this, new SocketTimeoutError())
-  })
   socket
     .setNoDelay(true)
+    .setTimeout(client[kSocketTimeout])
     .on(protocol === 'https:' ? 'secureConnect' : 'connect', function () {
       client[kReset] = false
       client[kRetryDelay] = 0
       client.emit('connect')
       resume(client)
+    })
+    .on('timeout', function () {
+      util.destroy(this, new SocketTimeoutError())
     })
     .on('data', /* istanbul ignore next */ function () {
       /* istanbul ignore next */
@@ -796,6 +798,8 @@ function write (client, request) {
   if (contentLength !== null) {
     socket.write(`content-length: ${contentLength}\r\n`, 'ascii')
   }
+
+  // TODO: keep-alive timeout=client[kSocketTimeout]?
 
   if (method === 'HEAD') {
     // https://github.com/mcollina/undici/issues/258

--- a/lib/request.js
+++ b/lib/request.js
@@ -122,6 +122,11 @@ class Request extends AsyncResource {
             key.toLowerCase() === 'connection'
           ) {
             throw new InvalidArgumentError('invalid connection header')
+          } else if (
+            key.length === 10 &&
+            key.toLowerCase() === 'keep-alive'
+          ) {
+            throw new InvalidArgumentError('invalid keep-alive header')
           } else {
             header += `${key}: ${val}\r\n`
           }

--- a/test/invalid-headers.js
+++ b/test/invalid-headers.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { Client, errors } = require('..')
 
 test('invalid headers', (t) => {
-  t.plan(5)
+  t.plan(6)
 
   const client = new Client('http://localhost:3000')
   t.teardown(client.destroy.bind(client))
@@ -33,6 +33,16 @@ test('invalid headers', (t) => {
     method: 'GET',
     headers: {
       connection: 'close'
+    }
+  }, (err, data) => {
+    t.ok(err instanceof errors.InvalidArgumentError)
+  })
+
+  client.request({
+    path: '/',
+    method: 'GET',
+    headers: {
+      'keep-alive': 'timeout=5'
     }
   }, (err, data) => {
     t.ok(err instanceof errors.InvalidArgumentError)


### PR DESCRIPTION
Provide a hint for the server to keep connection alive until it is
considered no longer re-usable by client. This reduces the risk of
a race where the client sends a request and the server closes it
before receiving it.

I don't think Node core uses this... but I guess it still could be useful.