### PR TITLE
fix: set default idle timeout to 4 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Options:
 - `idleTimeout`, the timeout after which a socket with no active requests
   will be released and no longer re-used for subsequent requests. This value
   is an upper bound and might be reduced by keep-alive hints from the server.
-  Default: `30e3` milliseconds (30s).
+  Default: `4e3` milliseconds (4s).
 
 - `requestTimeout`, the timeout after which a request will time out, in
   milliseconds. Monitors time between request being enqueued and receiving

--- a/lib/client.js
+++ b/lib/client.js
@@ -133,7 +133,7 @@ class Client extends EventEmitter {
     this[kUrl] = url
     this[kSocketPath] = socketPath
     this[kSocketTimeout] = socketTimeout == null ? 30e3 : socketTimeout
-    this[kIdleTimeout] = idleTimeout == null ? 30e3 : idleTimeout
+    this[kIdleTimeout] = idleTimeout == null ? 4e3 : idleTimeout
     this[kKeepAliveTimeout] = this[kIdleTimeout]
     this[kRequestTimeout] = requestTimeout == null ? 30e3 : requestTimeout
     this[kClosed] = false


### PR DESCRIPTION
Node HTTP server seem to have a default of 5 seconds and
we should be below that.

Fixes: https://github.com/mcollina/undici/issues/276