### PR TITLE
fix: stream must return Writeable

### DIFF
--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -56,13 +56,8 @@ class StreamRequest extends Request {
       return
     }
 
-    if (!res) {
-      this.callback = null
-      callback(null, null)
-      return
-    }
-
     if (
+      !res ||
       typeof res.write !== 'function' ||
       typeof res.end !== 'function' ||
       typeof res.on !== 'function'

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -43,48 +43,6 @@ test('stream get', (t) => {
   })
 })
 
-test('stream get skip body', (t) => {
-  t.plan(12)
-
-  const server = createServer((req, res) => {
-    t.strictEqual('/', req.url)
-    t.strictEqual('GET', req.method)
-    t.strictEqual('localhost', req.headers.host)
-    res.setHeader('content-type', 'text/plain')
-    res.end('hello')
-  })
-  t.tearDown(server.close.bind(server))
-
-  server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}`)
-    t.tearDown(client.close.bind(client))
-
-    client.stream({
-      path: '/',
-      method: 'GET'
-    }, ({ statusCode, headers }) => {
-      t.strictEqual(statusCode, 200)
-      t.strictEqual(headers['content-type'], 'text/plain')
-
-      // Don't return writable. Skip the body.
-    }, (err) => {
-      t.error(err)
-    })
-
-    client.stream({
-      path: '/',
-      method: 'GET'
-    }, ({ statusCode, headers }) => {
-      t.strictEqual(statusCode, 200)
-      t.strictEqual(headers['content-type'], 'text/plain')
-
-      // Don't return writable. Skip the body.
-    }).then(() => {
-      t.pass()
-    })
-  })
-})
-
 test('stream GET destroy res', (t) => {
   t.plan(14)
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -7,6 +7,7 @@ const { Pool, errors } = require('..')
 const { createServer } = require('http')
 const { EventEmitter } = require('events')
 const { promisify } = require('util')
+const { PassThrough } = require('stream')
 const eos = require('stream').finished
 
 test('basic get', (t) => {
@@ -114,6 +115,7 @@ test('stream get async/await', async (t) => {
   await client.stream({ path: '/', method: 'GET' }, ({ statusCode, headers }) => {
     t.strictEqual(statusCode, 200)
     t.strictEqual(headers['content-type'], 'text/plain')
+    return new PassThrough()
   })
 })
 


### PR DESCRIPTION
keep it simple, if you don't care about the response, abort it. This aligns it with what the docs says.