### PR TITLE
refactor: async error

### DIFF
--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -30,6 +30,7 @@ class PipelineRequest extends Request {
       throw new InvalidArgumentError('invalid opts.onTrailers')
     }
 
+    this.error = null
     this.pause = null
     this.resume = null
     this.callback = callback
@@ -62,7 +63,11 @@ class PipelineRequest extends Request {
   }
 
   _onData (chunk) {
-    const { res } = this
+    const { error, res } = this
+
+    if (error) {
+      throw this.error
+    }
 
     if (!res(null, chunk)) {
       this.pause()
@@ -70,7 +75,11 @@ class PipelineRequest extends Request {
   }
 
   _onComplete (trailers) {
-    const { res } = this
+    const { error, res } = this
+
+    if (error) {
+      throw error
+    }
 
     if (trailers && this.onTrailers) {
       this.onTrailers({ trailers, opaque: this.opaque })
@@ -158,16 +167,8 @@ module.exports = function (client, opts, handler) {
         util.destroy(req, err)
         util.destroy(res, err)
 
-        if (err) {
-          request.onError(err)
-        }
-
-        request.runInAsyncScope(
-          callback,
-          null,
-          err,
-          null
-        )
+        request.error = err
+        request.runInAsyncScope(callback, null, err)
       }
     }).on('prefinish', () => {
       // Node < 15 does not call _final in same tick.

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -22,16 +22,21 @@ class RequestResponse extends Readable {
     this[kRequest].resume()
   }
 
-  _destroy (err, callback) {
+  _destroy (err, cb) {
     if (!err && !this._readableState.endEmitted) {
       err = new RequestAbortedError()
     }
 
     if (err) {
-      this[kRequest].onError(err)
+      const { callback } = this[kRequest]
+      if (callback) {
+        this.callback = null
+        process.nextTick(callback, err, null)
+      }
     }
 
-    this[kRequest].runInAsyncScope(callback, null, err, null)
+    this[kRequest].error = err
+    this[kRequest].runInAsyncScope(cb, null, err, null)
   }
 }
 
@@ -55,6 +60,7 @@ class RequestRequest extends Request {
 
     super(opts, client)
 
+    this.error = null
     this.pause = null
     this.resume = null
     this.callback = callback
@@ -85,7 +91,11 @@ class RequestRequest extends Request {
   }
 
   _onData (chunk) {
-    const { res } = this
+    const { error, res } = this
+
+    if (error) {
+      throw error
+    }
 
     if (!res.push(chunk)) {
       this.pause()
@@ -93,7 +103,11 @@ class RequestRequest extends Request {
   }
 
   _onComplete (trailers) {
-    const { res, opaque } = this
+    const { error, res, opaque } = this
+
+    if (error) {
+      throw error
+    }
 
     if (trailers && this.onTrailers) {
       this.onTrailers({ trailers, opaque })

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -33,6 +33,7 @@ class StreamRequest extends Request {
 
     super(opts, client)
 
+    this.error = null
     this.pause = null
     this.resume = null
     this.factory = factory
@@ -81,20 +82,15 @@ class StreamRequest extends Request {
     res.on('drain', this.resume)
     // TODO: Avoid finished. It registers an unecessary amount of listeners.
     finished(res, { readable: false }, (err) => {
-      if (err) {
-        this.onError(err)
-        return
-      }
-
       const { callback, res, opaque, trailers } = this
 
       this.res = null
-      if (!res.readable) {
-        util.destroy(res)
+      if (err || !res.readable) {
+        util.destroy(res, err)
       }
 
       this.callback = null
-      callback(null, { opaque, trailers })
+      callback(err, err ? null : { opaque, trailers })
     })
 
     if (typeof res.destroy === 'function') {
@@ -105,7 +101,11 @@ class StreamRequest extends Request {
   }
 
   _onData (chunk) {
-    const { res } = this
+    const { error, res } = this
+
+    if (error) {
+      throw error
+    }
 
     if (!res.write(chunk)) {
       this.pause()
@@ -113,7 +113,11 @@ class StreamRequest extends Request {
   }
 
   _onComplete (trailers) {
-    const { res, opaque } = this
+    const { error, res, opaque } = this
+
+    if (error) {
+      throw error
+    }
 
     this.trailers = trailers || {}
 
@@ -129,14 +133,12 @@ class StreamRequest extends Request {
 
     this.factory = null
 
-    if (callback) {
-      this.callback = null
-      process.nextTick(callback, err, null)
-    }
-
     if (res) {
       this.res = null
       util.destroy(res, err)
+    } else if (callback) {
+      this.callback = null
+      process.nextTick(callback, err, null)
     }
   }
 }

--- a/lib/request.js
+++ b/lib/request.js
@@ -267,21 +267,15 @@ class Request extends AsyncResource {
   onBody (chunk, offset, length) {
     assert(!this.upgrade && this.method !== 'CONNECT')
 
-    if (this.aborted) {
-      return null
+    if (this._onData) {
+      try {
+        this.runInAsyncScope(this._onData, this, chunk.slice(offset, offset + length))
+      } catch (err) {
+        this.onError(err)
+      }
     }
 
-    if (!this._onData) {
-      return true
-    }
-
-    try {
-      this.runInAsyncScope(this._onData, this, chunk.slice(offset, offset + length))
-    } catch (err) {
-      this.onError(err)
-    }
-
-    return true
+    return this.aborted ? null : true
   }
 
   onComplete (trailers) {


### PR DESCRIPTION
Propagate async errors without extending API surface.

Refs: https://github.com/mcollina/undici/issues/293

Alternative is to provide a `destroy/abort/error` function in `onConnect` in addition to `pause` and `resume` 