### PR TITLE
feat: dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 ```
-http - keepalive x 5,521 ops/sec ±3.37% (73 runs sampled)
-undici - pipeline x 9,292 ops/sec ±4.28% (79 runs sampled)
-undici - request x 11,949 ops/sec ±0.99% (85 runs sampled)
-undici - stream x 12,223 ops/sec ±0.76% (85 runs sampled)
+http - keepalive x 5,826 ops/sec ±1.45% (275 runs sampled)
+undici - pipeline x 7,281 ops/sec ±1.68% (273 runs sampled)
+undici - request x 11,700 ops/sec ±0.56% (278 runs sampled)
+undici - stream x 12,684 ops/sec ±0.72% (280 runs sampled)
+undici - dispatch x 13,446 ops/sec ±0.37% (276 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).
@@ -451,6 +452,34 @@ there might still be some progress on dispatched requests.
 
 Returns a promise if no callback is provided.
 
+
+<a name='dispatch'></a>
+#### `client.dispatch(opts, handler): Promise|Void`
+
+This is the low level API which all the preceeding API's are implemented on top of.
+
+Options:
+
+* ... same as [`client.request(opts[, callback])`][request].
+
+The `handler` parameter is defined as follow:
+
+* `onUpgrade(statusCode, headers, socket): Void`, invoked when request is upgraded  either due to a `Upgrade` header or `CONNECT` method.
+  * `statusCode: Number`
+  * `headers: Object`
+  * `socket: Duplex`
+* `onHeaders(statusCode, headers, resume): Void`, invoked when statusCode and headers have been received. 
+  May be invoked multiple times due to 1xx informational headers.
+  * `statusCode: Number`
+  * `headers: Object`
+  * `resume(): Void`, resume `onData` after returning `false`.
+* `onData(chunk): Null|Boolean`, invoked when response payload data is received.
+  * `chunk: Buffer`
+* `onComplete(trailers): Void`, invoked when response payload and trailers have been received and the request has completed.
+  * `trailers: Object`
+* `onError(err): Void`, invoked when an error has occured.
+  * `err: Error`
+
 #### `client.pipelining: Number`
 
 Property to get and set the pipelining factor.
@@ -528,6 +557,10 @@ Calls [`client.upgrade(opts, callback)`][upgrade] on one of the clients.
 
 Calls [`client.connect(opts, callback)`][connect] on one of the clients.
 
+#### `pool.dispatch(opts, handler): Void`
+
+Calls [`client.dispatch(opts, handler)`][dispatch] on one of the clients.
+
 #### `pool.close([callback]): Promise|Void`
 
 Calls [`client.close(callback)`](#close) on all the clients.
@@ -604,3 +637,4 @@ MIT
 [pipeline]: #pipeline
 [upgrade]: #upgrade
 [connect]: #connect
+[dispatch]: #dispatch

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -3,8 +3,7 @@ const { Writable } = require('stream')
 const http = require('http')
 const Benchmark = require('benchmark')
 const undici = require('..')
-const { kEnqueue, kGetNext } = require('../lib/symbols')
-const Request = require('../lib/request')
+const { kGetNext } = require('../lib/symbols')
 
 // # Start the h2o server (in h2o repository)
 // # Then change the port below to 8080
@@ -121,7 +120,7 @@ suite
       })
     }
   })
-  .add('undici - simple', {
+  .add('undici - dispatch', {
     defer: true,
     fn: deferred => {
       const stream = new Writable({
@@ -133,14 +132,14 @@ suite
         deferred.resolve()
       })
       const client = pool[kGetNext]()
-      client[kEnqueue](new SimpleRequest(client, undiciOptions, stream))
+      client.dispatch(undiciOptions, new SimpleRequest(stream))
     }
   })
   .add('undici - noop', {
     defer: true,
     fn: deferred => {
       const client = pool[kGetNext]()
-      client[kEnqueue](new NoopRequest(client, undiciOptions, deferred))
+      client.dispatch(undiciOptions, new NoopRequest(deferred))
     }
   })
   .on('cycle', event => {
@@ -148,36 +147,35 @@ suite
   })
   .run()
 
-class NoopRequest extends Request {
-  constructor (client, opts, deferred) {
-    super(opts, client)
+class NoopRequest {
+  constructor (deferred) {
     this.deferred = deferred
   }
 
-  _onHeaders () {}
+  _onHeaders () {
 
-  _onData () {}
+  }
 
-  _onComplete () {
+  _onData (chunk) {
+    return true
+  }
+
+  _onComplete (trailers) {
     this.deferred.resolve()
   }
 }
 
-class SimpleRequest extends Request {
-  constructor (client, opts, dst) {
-    super(opts, client)
+class SimpleRequest {
+  constructor (dst) {
     this.dst = dst
-    this.dst.on('drain', () => {
-      this.resume()
-    })
   }
 
   _onHeaders (statusCode, headers, resume) {
-    this.resume = resume
+    this.dst.on('drain', resume)
   }
 
-  _onData (chunk, offset, length) {
-    return this.dst.write(chunk.slice(offset, offset + length))
+  _onData (chunk) {
+    return this.dst.write(chunk)
   }
 
   _onComplete () {

--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -1,36 +1,16 @@
 'use strict'
 
-const Request = require('./request')
 const {
   InvalidArgumentError
 } = require('./errors')
-const { kEnqueue } = require('./symbols')
 
-class ConnectRequest extends Request {
+class ConnectRequest {
   constructor (client, opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    const {
-      path,
-      headers,
-      servername,
-      signal,
-      requestTimeout,
-      opaque = null
-    } = opts
-
-    super({
-      path,
-      method: 'CONNECT',
-      headers,
-      servername,
-      signal,
-      requestTimeout
-    }, client)
-
-    this.opaque = opaque
+    this.opaque = opts.opaque || null
     this.callback = callback
   }
 
@@ -70,7 +50,21 @@ module.exports = function connect (client, opts, callback) {
   }
 
   try {
-    client[kEnqueue](new ConnectRequest(client, opts, callback))
+    const {
+      path,
+      headers,
+      servername,
+      signal,
+      requestTimeout
+    } = opts
+    client.dispatch({
+      path,
+      method: 'CONNECT',
+      headers,
+      servername,
+      signal,
+      requestTimeout
+    }, new ConnectRequest(client, opts, callback))
   } catch (err) {
     process.nextTick(callback, err, null)
   }

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -10,17 +10,16 @@ const {
   InvalidReturnValueError,
   RequestAbortedError
 } = require('./errors')
-const Request = require('./request')
 const util = require('./util')
-const { kEnqueue } = require('./symbols')
+const { AsyncResource } = require('async_hooks')
 
 // TODO: Refactor
 
 const kResume = Symbol('resume')
 
-class PipelineRequest extends Request {
+class PipelineRequest extends AsyncResource {
   constructor (client, opts, callback) {
-    super(opts, client)
+    super('UNDICI_PIPELINE')
 
     if (opts.onInfo && typeof opts.onInfo !== 'function') {
       throw new InvalidArgumentError('invalid opts.onInfo')
@@ -42,13 +41,13 @@ class PipelineRequest extends Request {
 
     if (statusCode < 200) {
       if (this.onInfo) {
-        this.onInfo({ statusCode, headers, opaque })
+        this.runInAsyncScope(this.onInfo, this, { statusCode, headers, opaque })
       }
       return
     }
 
     this.callback = null
-    this.res = callback.call(this, null, {
+    this.res = this.runInAsyncScope(callback, this, null, {
       statusCode,
       headers,
       opaque,
@@ -59,18 +58,14 @@ class PipelineRequest extends Request {
   _onData (chunk) {
     const { res } = this
 
-    return res ? res(null, chunk) : null
+    return this.runInAsyncScope(res, null, null, chunk)
   }
 
   _onComplete (trailers) {
     const { res } = this
 
-    if (!res) {
-      return
-    }
-
     if (trailers && this.onTrailers) {
-      this.onTrailers({ trailers, opaque: this.opaque })
+      this.runInAsyncScope(this.onTrailers, null, { trailers, opaque: this.opaque })
     }
 
     res(null, null)
@@ -81,12 +76,12 @@ class PipelineRequest extends Request {
 
     if (res) {
       this.res = null
-      res(err, null)
+      this.runInAsyncScope(res, null, err, null)
     }
 
     if (callback) {
       this.callback = null
-      callback.call(this, err, null)
+      this.runInAsyncScope(callback, null, err, null)
     }
   }
 }
@@ -155,15 +150,10 @@ module.exports = function (client, opts, handler) {
         util.destroy(req, err)
         util.destroy(res, err)
 
-        if (err) {
-          request.onError(err)
-        }
-
         request.runInAsyncScope(
           callback,
           null,
-          err,
-          null
+          err
         )
       }
     }).on('prefinish', () => {
@@ -270,7 +260,7 @@ module.exports = function (client, opts, handler) {
       }
     })
 
-    client[kEnqueue](request)
+    client.dispatch(opts, request)
 
     return ret
   } catch (err) {

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -1,13 +1,12 @@
 'use strict'
 
 const { Readable } = require('stream')
-const Request = require('./request')
 const {
   InvalidArgumentError,
   RequestAbortedError
 } = require('./errors')
 const util = require('./util')
-const { kEnqueue } = require('./symbols')
+const { AsyncResource } = require('async_hooks')
 
 const kRequest = Symbol('request')
 
@@ -23,16 +22,14 @@ class RequestResponse extends Readable {
       err = new RequestAbortedError()
     }
 
-    if (err) {
-      this[kRequest].onError(err)
-    }
-
     this[kRequest].runInAsyncScope(callback, null, err, null)
   }
 }
 
-class RequestRequest extends Request {
+class RequestRequest extends AsyncResource {
   constructor (client, opts, callback) {
+    super('UNDICI_REQUEST')
+
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
@@ -49,8 +46,6 @@ class RequestRequest extends Request {
       throw new InvalidArgumentError('invalid opts.onTrailers')
     }
 
-    super(opts, client)
-
     this.opaque = opts.opaque || null
     this.callback = callback
     this.res = null
@@ -63,7 +58,7 @@ class RequestRequest extends Request {
 
     if (statusCode < 200) {
       if (this.onInfo) {
-        this.onInfo({ statusCode, headers, opaque })
+        this.runInAsyncScope(this.onInfo, null, { statusCode, headers, opaque })
       }
       return
     }
@@ -73,22 +68,33 @@ class RequestRequest extends Request {
     this.callback = null
     this.res = body
 
-    callback(null, { statusCode, headers, opaque, body })
+    this.runInAsyncScope(callback, null, null, { statusCode, headers, opaque, body })
   }
 
   _onData (chunk) {
     const { res } = this
-    return res.push(chunk)
+
+    if (this.runInAsyncScope(res.push, res, chunk)) {
+      return true
+    } else if (!res._readableState.destroyed) {
+      return false
+    } else {
+      return null
+    }
   }
 
   _onComplete (trailers) {
     const { res, opaque } = this
 
-    if (trailers && this.onTrailers) {
-      this.onTrailers({ trailers, opaque })
+    if (res.destroyed) {
+      return
     }
 
-    res.push(null)
+    if (trailers && this.onTrailers) {
+      this.runInAsyncScope(this.onTrailers, null, { trailers, opaque })
+    }
+
+    this.runInAsyncScope(res.push, res, null)
   }
 
   _onError (err) {
@@ -96,7 +102,7 @@ class RequestRequest extends Request {
 
     if (callback) {
       this.callback = null
-      callback(err, null)
+      this.runInAsyncScope(callback, null, err, null)
     }
 
     if (res) {
@@ -120,7 +126,7 @@ module.exports = function request (client, opts, callback) {
   }
 
   try {
-    client[kEnqueue](new RequestRequest(client, opts, callback))
+    client.dispatch(opts, new RequestRequest(client, opts, callback))
   } catch (err) {
     process.nextTick(callback, err, null)
   }

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -1,16 +1,17 @@
 'use strict'
 
 const { finished } = require('stream')
-const Request = require('./request')
 const {
   InvalidArgumentError,
   InvalidReturnValueError
 } = require('./errors')
 const util = require('./util')
-const { kEnqueue } = require('./symbols')
+const { AsyncResource } = require('async_hooks')
 
-class StreamRequest extends Request {
+class StreamRequest extends AsyncResource {
   constructor (client, opts, factory, callback) {
+    super('UNDICI_STREAM')
+
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
@@ -31,8 +32,6 @@ class StreamRequest extends Request {
       throw new InvalidArgumentError('invalid opts.onTrailers')
     }
 
-    super(opts, client)
-
     this.opaque = opts.opaque || null
     this.factory = factory
     this.callback = callback
@@ -47,13 +46,13 @@ class StreamRequest extends Request {
 
     if (statusCode < 200) {
       if (this.onInfo) {
-        this.onInfo({ statusCode, headers, opaque })
+        this.runInAsyncScope(this.onInfo, null, { statusCode, headers, opaque })
       }
       return
     }
 
     this.factory = null
-    const res = factory({ statusCode, headers, opaque })
+    const res = this.runInAsyncScope(factory, null, { statusCode, headers, opaque })
 
     const { callback } = this
 
@@ -74,11 +73,6 @@ class StreamRequest extends Request {
     res.on('drain', resume)
     // TODO: Avoid finished. It registers an unecessary amount of listeners.
     finished(res, { readable: false }, (err) => {
-      if (err) {
-        this.onError(err)
-        return
-      }
-
       const { callback, res, opaque, trailers } = this
 
       if (err || !res.readable) {
@@ -98,19 +92,30 @@ class StreamRequest extends Request {
 
   _onData (chunk) {
     const { res } = this
-    return res.write(chunk)
+
+    if (this.runInAsyncScope(res.write, res, chunk)) {
+      return true
+    } else if (!util.isDestroyed(res)) {
+      return false
+    } else {
+      return null
+    }
   }
 
   _onComplete (trailers) {
     const { res, opaque } = this
 
+    if (util.isDestroyed(res)) {
+      return
+    }
+
     this.trailers = trailers || {}
 
     if (trailers && this.onTrailers) {
-      this.onTrailers({ trailers, opaque })
+      this.runInAsyncScope(this.onTrailers, null, { trailers, opaque })
     }
 
-    res.end()
+    this.runInAsyncScope(res.end, res)
   }
 
   _onError (err) {
@@ -121,11 +126,9 @@ class StreamRequest extends Request {
     if (res) {
       this.res = null
       util.destroy(res, err)
-    }
-
-    if (callback) {
+    } else if (callback) {
       this.callback = null
-      callback(err, null)
+      this.runInAsyncScope(callback, null, err, null)
     }
   }
 }
@@ -144,7 +147,7 @@ module.exports = function stream (client, opts, factory, callback) {
   }
 
   try {
-    client[kEnqueue](new StreamRequest(client, opts, factory, callback))
+    client.dispatch(opts, new StreamRequest(client, opts, factory, callback))
   } catch (err) {
     process.nextTick(callback, err, null)
   }

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -1,39 +1,16 @@
 'use strict'
 
-const Request = require('./request')
 const {
   InvalidArgumentError
 } = require('./errors')
-const { kEnqueue } = require('./symbols')
 
-class UpgradeRequest extends Request {
+class UpgradeRequest {
   constructor (client, opts, callback) {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
     }
 
-    const {
-      path,
-      method,
-      headers,
-      servername,
-      signal,
-      requestTimeout,
-      protocol,
-      opaque = null
-    } = opts
-
-    super({
-      path,
-      method: method || 'GET',
-      headers,
-      servername,
-      signal,
-      requestTimeout,
-      upgrade: protocol || 'Websocket'
-    }, client)
-
-    this.opaque = opaque
+    this.opaque = opts.opaque || null
     this.callback = callback
   }
 
@@ -72,7 +49,24 @@ module.exports = function upgrade (client, opts, callback) {
   }
 
   try {
-    client[kEnqueue](new UpgradeRequest(client, opts, callback))
+    const {
+      path,
+      method,
+      headers,
+      servername,
+      signal,
+      requestTimeout,
+      protocol
+    } = opts
+    client.dispatch({
+      path,
+      method: method || 'GET',
+      headers,
+      servername,
+      signal,
+      requestTimeout,
+      upgrade: protocol || 'Websocket'
+    }, new UpgradeRequest(client, opts, callback))
   } catch (err) {
     process.nextTick(callback, err, null)
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,7 @@ const { HTTPParser } = process.binding('http_parser') // eslint-disable-line
 const EventEmitter = require('events')
 const assert = require('assert')
 const util = require('./util')
+const Request = require('./request')
 const {
   ContentLengthMismatchError,
   SocketTimeoutError,
@@ -263,6 +264,10 @@ class Client extends EventEmitter {
         this.once('connect', cb)
       }
     }
+  }
+
+  dispatch (opts, handler) {
+    this[kEnqueue](new Request(opts, this, handler))
   }
 
   [kEnqueue] (request) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -66,6 +66,10 @@ class Pool {
     return getNext(this).connect(opts, callback)
   }
 
+  dispatch (opts, handler) {
+    return getNext(this).dispatch(opts, handler)
+  }
+
   close (cb) {
     const promise = Promise.all(this[kClients].map(c => c.close()))
     if (cb) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -250,14 +250,13 @@ class Request extends AsyncResource {
     assert(!this.upgrade && this.method !== 'CONNECT')
 
     if (this.aborted) {
-      return null
+      return
     }
 
     try {
       return this.runInAsyncScope(this._onData, this, chunk.slice(offset, offset + length))
     } catch (err) {
       this.onError(err)
-      return null
     }
   }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { AsyncResource } = require('async_hooks')
 const {
   InvalidArgumentError,
   RequestAbortedError,
@@ -17,7 +16,7 @@ const kTimeout = Symbol('timeout')
 const kResume = Symbol('resume')
 const kSignal = Symbol('signal')
 
-class Request extends AsyncResource {
+class Request {
   constructor ({
     path,
     method,
@@ -31,9 +30,7 @@ class Request extends AsyncResource {
   }, {
     [kRequestTimeout]: defaultRequestTimeout,
     [kUrl]: { hostname: defaultHostname }
-  }) {
-    super('UNDICI_REQ')
-
+  }, handler) {
     if (typeof path !== 'string' || path[0] !== '/') {
       throw new InvalidArgumentError('path must be a valid path')
     }
@@ -57,6 +54,8 @@ class Request extends AsyncResource {
     if (requestTimeout != null && (!Number.isInteger(requestTimeout) || requestTimeout < 0)) {
       throw new InvalidArgumentError('requestTimeout must be a positive integer or zero')
     }
+
+    this.handler = handler
 
     this.method = method
 
@@ -215,7 +214,7 @@ class Request extends AsyncResource {
     }
 
     try {
-      this.runInAsyncScope(this._onUpgrade, this, statusCode, headers, socket)
+      this.handler._onUpgrade(statusCode, headers, socket)
     } catch (err) {
       this.onError(err)
     }
@@ -240,7 +239,7 @@ class Request extends AsyncResource {
     }
 
     try {
-      this.runInAsyncScope(this._onHeaders, this, statusCode, headers, resume)
+      this.handler._onHeaders(statusCode, headers, resume)
     } catch (err) {
       this.onError(err)
     }
@@ -254,7 +253,7 @@ class Request extends AsyncResource {
     }
 
     try {
-      return this.runInAsyncScope(this._onData, this, chunk.slice(offset, offset + length))
+      return this.handler._onData(chunk.slice(offset, offset + length))
     } catch (err) {
       this.onError(err)
     }
@@ -287,7 +286,7 @@ class Request extends AsyncResource {
     }
 
     try {
-      this.runInAsyncScope(this._onComplete, this, trailers)
+      return this.handler._onComplete(trailers)
     } catch (err) {
       this.onError(err)
     }
@@ -329,9 +328,9 @@ class Request extends AsyncResource {
       }
     }
 
-    process.nextTick((self, err) => {
-      self.runInAsyncScope(self._onError, self, err)
-    }, this, err)
+    process.nextTick((handler, err) => {
+      handler._onError(err)
+    }, this.handler, err)
   }
 }
 


### PR DESCRIPTION
Makes our internal API public. This is the API which our public API is implemented on top.

There is need for some internal cleanup and refactor post this PR. I've tried to keep the changes as small as possible for easy of review.

I am not 100% satisfied with the API. However, I believe it does fullfil functional and performance requirements. Would appreciate some feedback and maybe ideas. I suspect this API might evolve/improve over time and be less stable than the other ones.

Some problems that might or might not need to be resolved:

- ~~There is now two `AsyncResource`s, the `handler` object and `Request` object. Depending on whether the implementation needs to asynchronously propagate async scope.~~

- ~~It's a bit weird that `_onConnect` takes a `resume` function.~~
- ~~Not sure about naming for `_onConnect`.~~
- It's a bit weird that `_onData` should return `null` to indicate an aborted message.

Refs: https://github.com/mcollina/undici/issues/293

```js
_onUpgrade(statusCode, headers, socker): Void
_onHeaders(statusCode, headers, resume): Void
_onData(chunk): Boolean|Null
_onComplete(trailers): Void
_onErrror(err): Void
```