### PR TITLE
refactor: apply opaque as this instead of passing as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
 
 * `path: String`
 * `method: String`
-* `opaque: Any`
+* `opaque: Any`, applied as `this` in `callback`,
 * `body: String|Buffer|Uint8Array|stream.Readable|Null`.
   Default: `null`.
 * `headers: Object|Null`, an object with header-value pairs.
@@ -134,7 +134,6 @@ If you don't specify a `host` header, it will be derived from the `url` of the c
 The `data` parameter in `callback` is defined as follow:
 
 * `statusCode: Number`
-* `opaque: Any`
 * `headers: Object`, an object where all keys have been lowercased.
 * `body: stream.Readable` response payload. A user **must**
   either fully consume or destroy the body unless there is an error, or no further requests
@@ -248,11 +247,10 @@ The `data` parameter in `factory` is defined as follow:
 
 * `statusCode: Number`
 * `headers: Object`, an object where all keys have been lowercased.
-* `opaque: Any`
+* `opaque: Any`, applied as `this` in `handler` and `callback`,
 
 The `data` parameter in `callback` is defined as follow:
 
-* `opaque: Any`
 * `trailers: Object`, an object where all keys have been lowercased.
 
 Returns a promise if no callback is provided.
@@ -265,16 +263,18 @@ const fs = require('fs')
 client.stream({
   path: '/',
   method: 'GET',
-  opaque: filename
-}, ({ statusCode, headers, opaque: filename }) => {
+  opaque: { filename }
+}, function ({ statusCode, headers }) {
+  const { filename } = this
   console.log('response received', statusCode)
   console.log('headers', headers)
   return fs.createWriteStream(filename)
-}, (err) => {
+}, function (err) {
+  const { filename } = this
   if (err) {
-    console.error('failure', err)
+    console.error('failure', filename, err)
   } else {
-    console.log('success')
+    console.log('success', filename)
   }
 })
 ```
@@ -294,7 +294,7 @@ Instead of:
 function (req, res) {
    return client.stream(opts, (data) => {
      // Creates closure to capture `res`.
-     proxy({ ...data, opaque: res })
+     proxy.call(res, data)
    }
 }
 ```
@@ -314,7 +314,7 @@ The `data` parameter in `handler` is defined as follow:
 
 * `statusCode: Number`
 * `headers: Object`, an object where all keys have been lowercased.
-* `opaque: Any`
+* `opaque: Any`, applied as `this` in `handler`,
 * `body: stream.Readable` response payload. A user **must**
   either fully consume or destroy the body unless there is an error, or no further requests
   will be processed.
@@ -371,7 +371,7 @@ Upgrade to a different protocol.
 Options:
 
 * `path: String`
-* `opaque: Any`
+* `opaque: Any`, applied as `this` in `callback`,
 * `method: String`
   Default: `GET`
 * `headers: Object|Null`, an object with header-value pairs.
@@ -389,7 +389,6 @@ The `data` parameter in `callback` is defined as follow:
 
 * `headers: Object`, an object where all keys have been lowercased.
 * `socket: Duplex`
-* `opaque`
 
 Returns a promise if no callback is provided.
 
@@ -401,7 +400,7 @@ Starts two-way communications with the requested resource.
 Options:
 
 * `path: String`
-* `opaque: Any`
+* `opaque: Any`, applied as `this` in `callback`,
 * `headers: Object|Null`, an object with header-value pairs.
   Default: `null`
 * `signal: AbortController|EventEmitter|Null`.
@@ -416,7 +415,6 @@ The `data` parameter in `callback` is defined as follow:
 * `statusCode: Number`
 * `headers: Object`, an object where all keys have been lowercased.
 * `socket: Duplex`
-* `opaque: Any`
 
 Returns a promise if no callback is provided.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Machine: 2.8GHz AMD EPYC 7402P<br/>
 Configuration: Node v14.4, HTTP/1.1 without TLS, 100 connections, Linux 5.4.12-1-lts
 
 ```
-http - keepalive x 5,826 ops/sec ±1.45% (275 runs sampled)
-undici - pipeline x 7,281 ops/sec ±1.68% (273 runs sampled)
-undici - request x 11,700 ops/sec ±0.56% (278 runs sampled)
-undici - stream x 12,684 ops/sec ±0.72% (280 runs sampled)
-undici - dispatch x 13,446 ops/sec ±0.37% (276 runs sampled)
+http - keepalive x 5,847 ops/sec ±2.69% (276 runs sampled)
+undici - pipeline x 8,748 ops/sec ±2.90% (277 runs sampled)
+undici - request x 12,166 ops/sec ±0.80% (278 runs sampled)
+undici - stream x 12,969 ops/sec ±0.82% (278 runs sampled)
+undici - dispatch x 13,736 ops/sec ±0.60% (280 runs sampled)
 ```
 
 The benchmark is a simple `hello world` [example](benchmarks/index.js).

--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -18,20 +18,19 @@ class ConnectRequest {
     const { callback, opaque } = this
 
     this.callback = null
-    callback(null, {
+    callback.call(opaque, null, {
       statusCode,
       headers,
-      socket,
-      opaque
+      socket
     })
   }
 
   _onError (err) {
-    const { callback } = this
+    const { callback, opaque } = this
 
     if (callback) {
       this.callback = null
-      callback(err, null)
+      callback.call(opaque, err, null)
     }
   }
 }

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -118,10 +118,9 @@ class PipelineHandler {
     let body
     try {
       this.handler = null
-      body = handler({
+      body = handler.call(opaque, {
         statusCode,
         headers,
-        opaque,
         body: this.res
       })
     } catch (err) {

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -51,7 +51,11 @@ class RequestHandler extends AsyncResource {
     this.callback = null
     this.res = body
 
-    this.runInAsyncScope(callback, null, null, { statusCode, headers, opaque, body })
+    this.runInAsyncScope(callback, opaque, null, {
+      statusCode,
+      headers,
+      body
+    })
   }
 
   _onData (chunk) {
@@ -77,11 +81,11 @@ class RequestHandler extends AsyncResource {
   }
 
   _onError (err) {
-    const { res, callback } = this
+    const { res, callback, opaque } = this
 
     if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, null)
+      this.runInAsyncScope(callback, opaque, err, null)
     }
 
     if (res) {

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -39,7 +39,11 @@ class StreamHandler extends AsyncResource {
     }
 
     this.factory = null
-    const res = this.runInAsyncScope(factory, null, { statusCode, headers, opaque })
+    const res = this.runInAsyncScope(factory, opaque, {
+      statusCode,
+      headers,
+      opaque
+    })
 
     if (
       !res ||
@@ -60,7 +64,12 @@ class StreamHandler extends AsyncResource {
       }
 
       this.callback = null
-      this.runInAsyncScope(callback, null, err, err ? null : { opaque, trailers })
+
+      if (err) {
+        this.runInAsyncScope(callback, opaque, err, null)
+      } else {
+        this.runInAsyncScope(callback, opaque, null, { trailers })
+      }
     })
 
     this.res = res
@@ -91,7 +100,7 @@ class StreamHandler extends AsyncResource {
   }
 
   _onError (err) {
-    const { res, callback } = this
+    const { res, callback, opaque } = this
 
     this.factory = null
 
@@ -100,7 +109,7 @@ class StreamHandler extends AsyncResource {
       util.destroy(res, err)
     } else if (callback) {
       this.callback = null
-      this.runInAsyncScope(callback, null, err, null)
+      this.runInAsyncScope(callback, opaque, err, null)
     }
   }
 }

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -18,19 +18,18 @@ class UpgradeHandler {
     const { callback, opaque } = this
 
     this.callback = null
-    callback(null, {
+    callback.call(opaque, null, {
       headers,
-      socket,
-      opaque
+      socket
     })
   }
 
   _onError (err) {
-    const { callback } = this
+    const { callback, opaque } = this
 
     if (callback) {
       this.callback = null
-      callback(err, null)
+      callback.call(opaque, err, null)
     }
   }
 }

--- a/test/client-stream.js
+++ b/test/client-stream.js
@@ -26,17 +26,17 @@ test('stream get', (t) => {
       path: '/',
       method: 'GET',
       opaque: new PassThrough()
-    }, ({ statusCode, headers, opaque: pt }) => {
+    }, function ({ statusCode, headers }) {
       t.strictEqual(statusCode, 200)
       t.strictEqual(headers['content-type'], 'text/plain')
       const bufs = []
-      pt.on('data', (buf) => {
+      this.on('data', (buf) => {
         bufs.push(buf)
       })
-      pt.on('end', () => {
+      this.on('end', () => {
         t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
       })
-      return pt
+      return this
     }, (err) => {
       t.error(err)
     })


### PR DESCRIPTION
This is more javascripty and also makes the opaque context available in the error case.