### PR TITLE
perf: improved pool balancing

### DIFF
--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -37,7 +37,7 @@ class ConnectHandler extends AsyncResource {
   }
 }
 
-module.exports = function connect (client, opts, callback) {
+function connect (client, opts, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
       connect(client, opts, (err, data) => {
@@ -73,4 +73,9 @@ module.exports = function connect (client, opts, callback) {
   } catch (err) {
     process.nextTick(callback, err, null)
   }
+}
+
+module.exports = {
+  connect,
+  ConnectHandler
 }

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -212,7 +212,7 @@ class PipelineHandler extends AsyncResource {
   }
 }
 
-module.exports = function pipeline (client, opts, handler) {
+function pipeline (client, opts, handler) {
   try {
     if (!opts || typeof opts !== 'object') {
       throw new InvalidArgumentError('invalid opts')
@@ -245,4 +245,9 @@ module.exports = function pipeline (client, opts, handler) {
   } catch (err) {
     return new PassThrough().destroy(err)
   }
+}
+
+module.exports = {
+  pipeline,
+  PipelineHandler
 }

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -96,7 +96,7 @@ class RequestHandler extends AsyncResource {
   }
 }
 
-module.exports = function request (client, opts, callback) {
+function request (client, opts, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
       request(client, opts, (err, data) => {
@@ -114,4 +114,9 @@ module.exports = function request (client, opts, callback) {
   } catch (err) {
     process.nextTick(callback, err, null)
   }
+}
+
+module.exports = {
+  request,
+  RequestHandler
 }

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -115,7 +115,7 @@ class StreamHandler extends AsyncResource {
   }
 }
 
-module.exports = function stream (client, opts, factory, callback) {
+function stream (client, opts, factory, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
       stream(client, opts, factory, (err, data) => {
@@ -133,4 +133,9 @@ module.exports = function stream (client, opts, factory, callback) {
   } catch (err) {
     process.nextTick(callback, err, null)
   }
+}
+
+module.exports = {
+  stream,
+  StreamHandler
 }

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -36,7 +36,7 @@ class UpgradeHandler extends AsyncResource {
   }
 }
 
-module.exports = function upgrade (client, opts, callback) {
+function upgrade (client, opts, callback) {
   if (callback === undefined) {
     return new Promise((resolve, reject) => {
       upgrade(client, opts, (err, data) => {
@@ -75,4 +75,9 @@ module.exports = function upgrade (client, opts, callback) {
   } catch (err) {
     process.nextTick(callback, err, null)
   }
+}
+
+module.exports = {
+  upgrade,
+  UpgradeHandler
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -54,11 +54,11 @@ const {
   kMaxKeepAliveTimeout,
   kKeepAliveTimeoutThreshold
 } = require('./symbols')
-const makeStream = require('./client-stream')
-const makeRequest = require('./client-request')
-const makePipeline = require('./client-pipeline')
-const makeUpgrade = require('./client-upgrade')
-const makeConnect = require('./client-connect')
+const makeStream = require('./client-stream').stream
+const makeRequest = require('./client-request').request
+const makePipeline = require('./client-pipeline').pipeline
+const makeUpgrade = require('./client-upgrade').upgrade
+const makeConnect = require('./client-connect').connect
 
 const CRLF = Buffer.from('\r\n', 'ascii')
 
@@ -225,7 +225,7 @@ class Client extends EventEmitter {
       return true
     }
 
-    if (this.pending && !this.connected) {
+    if (this.size && !this.connected) {
       return true
     }
 
@@ -802,6 +802,10 @@ function resume (client) {
     }
 
     if (!client.pending) {
+      if (!client.busy) {
+        // TODO: Only emit if was busy or not connected.
+        client.emit('drain')
+      }
       return
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -225,6 +225,10 @@ class Client extends EventEmitter {
       return true
     }
 
+    if (this.pending && !this.connected) {
+      return true
+    }
+
     if (this[kReset] || this[kWriting]) {
       return true
     }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -4,9 +4,13 @@ const Client = require('./client')
 const {
   InvalidArgumentError
 } = require('./errors')
+const { PassThrough } = require('stream')
 const {
-  kClients
+  kClients,
+  kQueue,
+  kPendingIdx
 } = require('./symbols')
+const { PipelineHandler } = require('./client-pipeline')
 
 class Pool {
   constructor (url, {
@@ -17,33 +21,107 @@ class Pool {
       throw new InvalidArgumentError('invalid connections')
     }
 
+    this[kQueue] = []
+    this[kPendingIdx] = 0
     this[kClients] = Array.from({
       length: connections || 10
     }, () => new Client(url, options))
+
+    const pool = this
+    function onDrain () {
+      while (pool[kPendingIdx] < pool[kQueue].length && !this.busy) {
+        const { method, args } = pool[kQueue][pool[kPendingIdx]]
+        pool[kQueue][pool[kPendingIdx]++] = null
+        method.apply(this, args)
+      }
+    }
+
+    for (const client of this[kClients]) {
+      client.on('drain', onDrain)
+    }
   }
 
   stream (opts, factory, callback) {
-    return getNext(this).stream(opts, factory, callback)
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.stream(opts, factory, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    enqueue(this, Client.prototype.stream, opts, factory, callback)
   }
 
   pipeline (opts, handler) {
-    return getNext(this).pipeline(opts, handler)
+    try {
+      const pipeline = new PipelineHandler(opts, handler)
+
+      const {
+        path,
+        method,
+        headers,
+        idempotent,
+        servername,
+        signal,
+        requestTimeout
+      } = opts
+
+      this.dispatch({
+        path,
+        method,
+        body: pipeline.req,
+        headers,
+        idempotent,
+        servername,
+        signal,
+        requestTimeout
+      }, pipeline)
+
+      return pipeline.ret
+    } catch (err) {
+      return new PassThrough().destroy(err)
+    }
   }
 
   request (opts, callback) {
-    return getNext(this).request(opts, callback)
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.request(opts, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    enqueue(this, Client.prototype.request, opts, callback)
   }
 
   upgrade (opts, callback) {
-    return getNext(this).upgrade(opts, callback)
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.upgrade(opts, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    enqueue(this, Client.prototype.upgrade, opts, callback)
   }
 
   connect (opts, callback) {
-    return getNext(this).connect(opts, callback)
+    if (callback === undefined) {
+      return new Promise((resolve, reject) => {
+        this.connect(opts, (err, data) => {
+          return err ? reject(err) : resolve(data)
+        })
+      })
+    }
+
+    enqueue(this, Client.prototype.connect, opts, callback)
   }
 
   dispatch (opts, handler) {
-    return getNext(this).dispatch(opts, handler)
+    enqueue(this, Client.prototype.dispatch, opts, handler)
   }
 
   close (cb) {
@@ -70,27 +148,17 @@ class Pool {
   }
 }
 
-function getNext (pool) {
-  let next
-  for (const client of pool[kClients]) {
-    if (client.busy) {
-      continue
+function enqueue (pool, method, ...args) {
+  const client = pool[kClients].find(client => !client.busy)
+  if (!client) {
+    pool[kQueue].push({ method, args })
+    if (pool[kPendingIdx] > 256) {
+      pool[kQueue].splice(0, pool[kPendingIdx])
+      pool[kPendingIdx] = 0
     }
-
-    if (!next) {
-      next = client
-    }
-
-    if (client.connected) {
-      return client
-    }
+  } else {
+    method.apply(client, args)
   }
-
-  if (next) {
-    return next
-  }
-
-  return pool[kClients][Math.floor(Math.random() * pool[kClients].length)]
 }
 
 module.exports = Pool

--- a/test/client-pipelining.js
+++ b/test/client-pipelining.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const { Client } = require('..')
 const { createServer } = require('http')
 const { finished, Readable } = require('stream')
+const { kConnect } = require('../lib/symbols')
 
 test('20 times GET with pipelining 10', (t) => {
   const num = 20
@@ -398,50 +399,52 @@ test('pipelining HEAD busy', (t) => {
     })
     t.tearDown(client.close.bind(client))
 
-    {
-      const body = new Readable({
-        read () { }
-      })
-      client.request({
-        path: '/',
-        method: 'GET',
-        body
-      }, (err, data) => {
-        t.error(err)
-        data.body
-          .resume()
-          .on('end', () => {
-            t.pass()
-          })
-      })
-      body.push(null)
-      t.strictEqual(client.busy, false)
-    }
+    client[kConnect](() => {
+      {
+        const body = new Readable({
+          read () { }
+        })
+        client.request({
+          path: '/',
+          method: 'GET',
+          body
+        }, (err, data) => {
+          t.error(err)
+          data.body
+            .resume()
+            .on('end', () => {
+              t.pass()
+            })
+        })
+        body.push(null)
+        t.strictEqual(client.busy, false)
+      }
 
-    {
-      const body = new Readable({
-        read () { }
-      })
-      client.request({
-        path: '/',
-        method: 'HEAD',
-        body
-      }, (err, data) => {
-        t.error(err)
-        data.body
-          .resume()
-          .on('end', () => {
-            t.pass()
-          })
-      })
-      body.push(null)
-      t.strictEqual(client.busy, true)
-    }
+      {
+        const body = new Readable({
+          read () { }
+        })
+        client.request({
+          path: '/',
+          method: 'HEAD',
+          body
+        }, (err, data) => {
+          t.error(err)
+          data.body
+            .resume()
+            .on('end', () => {
+              t.pass()
+            })
+        })
+        body.push(null)
+        t.strictEqual(client.busy, true)
+      }
+    })
   })
 })
 
 test('pipelining idempotent busy', (t) => {
-  t.plan(6)
+  t.plan(9)
 
   const server = createServer()
   server.on('request', (req, res) => {
@@ -472,28 +475,50 @@ test('pipelining idempotent busy', (t) => {
           })
       })
       body.push(null)
-      t.strictEqual(client.busy, false)
-    }
-
-    {
-      const body = new Readable({
-        read () { }
-      })
-      client.request({
-        path: '/',
-        method: 'GET',
-        idempotent: false,
-        body
-      }, (err, data) => {
-        t.error(err)
-        data.body
-          .resume()
-          .on('end', () => {
-            t.pass()
-          })
-      })
-      body.push(null)
       t.strictEqual(client.busy, true)
     }
+
+    client[kConnect](() => {
+      {
+        const body = new Readable({
+          read () { }
+        })
+        client.request({
+          path: '/',
+          method: 'GET',
+          body
+        }, (err, data) => {
+          t.error(err)
+          data.body
+            .resume()
+            .on('end', () => {
+              t.pass()
+            })
+        })
+        body.push(null)
+        t.strictEqual(client.busy, false)
+      }
+
+      {
+        const body = new Readable({
+          read () { }
+        })
+        client.request({
+          path: '/',
+          method: 'GET',
+          idempotent: false,
+          body
+        }, (err, data) => {
+          t.error(err)
+          data.body
+            .resume()
+            .on('end', () => {
+              t.pass()
+            })
+        })
+        body.push(null)
+        t.strictEqual(client.busy, true)
+      }
+    })
   })
 })


### PR DESCRIPTION
If all clients are busy then put requests in a queue and dispatch on first client that is no longer busy.