### PR TITLE
fix: change set-cookie header to always be an array

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,7 @@ function parseHeaders (headers, obj) {
     var key = headers[i].toLowerCase()
     var val = obj[key]
     if (!val) {
-      obj[key] = headers[i + 1]
+      obj[key] = key === 'set-cookie' ? [headers[i + 1]] : headers[i + 1]
     } else {
       if (!Array.isArray(val)) {
         val = [val]

--- a/test/client.js
+++ b/test/client.js
@@ -570,6 +570,35 @@ test('Set-Cookie', (t) => {
   })
 })
 
+test('Set-Cookie with a single cookie', (t) => {
+  t.plan(4)
+
+  const server = createServer((req, res) => {
+    res.setHeader('content-type', 'text/plain')
+    res.setHeader('Set-Cookie', 'a single cookie')
+    res.end('hello')
+  })
+  t.tearDown(server.close.bind(server))
+
+  server.listen(0, () => {
+    const client = new Client(`http://localhost:${server.address().port}`)
+    t.tearDown(client.close.bind(client))
+
+    client.request({ path: '/', method: 'GET' }, (err, { statusCode, headers, body }) => {
+      t.error(err)
+      t.strictEqual(statusCode, 200)
+      t.strictDeepEqual(headers['set-cookie'], ['a single cookie'])
+      const bufs = []
+      body.on('data', (buf) => {
+        bufs.push(buf)
+      })
+      body.on('end', () => {
+        t.strictEqual('hello', Buffer.concat(bufs).toString('utf8'))
+      })
+    })
+  })
+})
+
 test('ignore request header mutations', (t) => {
   t.plan(2)
 


### PR DESCRIPTION
For compatibility with the Node.js API `set-cookie` header, if present,
has to always be an array, even when there is only one value in it.

For reference, see https://nodejs.org/api/http.html#http_message_headers

There is also a possible compatibility problem with the way duplicate headers are handled right now since you always collect all duplicates to an array, but Node.js discards duplicates of some of the headers and joins the duplicate values with ', ' or '; ' for others. This can be fixed separately if you want full compatibility with Node.js, but for now, I only wanted to handle one issue that I discovered while using this package.