### PR TITLE
Fast socket2

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -42,97 +42,97 @@ const suite = new Benchmark.Suite()
 Benchmark.options.minSamples = 200
 
 suite
-  // .add('http - keepalive', {
-  //   defer: true,
-  //   fn: deferred => {
-  //     http.get(httpOptions, response => {
-  //       const stream = new Writable({
-  //         write (chunk, encoding, callback) {
-  //           callback()
-  //         }
-  //       })
-  //       stream.once('finish', () => {
-  //         deferred.resolve()
-  //       })
+  .add('http - keepalive', {
+    defer: true,
+    fn: deferred => {
+      http.get(httpOptions, response => {
+        const stream = new Writable({
+          write (chunk, encoding, callback) {
+            callback()
+          }
+        })
+        stream.once('finish', () => {
+          deferred.resolve()
+        })
 
-  //       response.pipe(stream)
-  //     })
-  //   }
-  // })
-  // .add('undici - pipeline', {
-  //   defer: true,
-  //   fn: deferred => {
-  //     pool
-  //       .pipeline(undiciOptions, data => {
-  //         return data.body
-  //       })
-  //       .end()
-  //       .pipe(new Writable({
-  //         write (chunk, encoding, callback) {
-  //           callback()
-  //         }
-  //       }))
-  //       .once('finish', () => {
-  //         deferred.resolve()
-  //       })
-  //   }
-  // })
-  // .add('undici - request', {
-  //   defer: true,
-  //   fn: deferred => {
-  //     pool.request(undiciOptions, (error, { body }) => {
-  //       if (error) {
-  //         throw error
-  //       }
+        response.pipe(stream)
+      })
+    }
+  })
+  .add('undici - pipeline', {
+    defer: true,
+    fn: deferred => {
+      pool
+        .pipeline(undiciOptions, data => {
+          return data.body
+        })
+        .end()
+        .pipe(new Writable({
+          write (chunk, encoding, callback) {
+            callback()
+          }
+        }))
+        .once('finish', () => {
+          deferred.resolve()
+        })
+    }
+  })
+  .add('undici - request', {
+    defer: true,
+    fn: deferred => {
+      pool.request(undiciOptions, (error, { body }) => {
+        if (error) {
+          throw error
+        }
 
-  //       const stream = new Writable({
-  //         write (chunk, encoding, callback) {
-  //           callback()
-  //         }
-  //       })
-  //       stream.once('finish', () => {
-  //         deferred.resolve()
-  //       })
+        const stream = new Writable({
+          write (chunk, encoding, callback) {
+            callback()
+          }
+        })
+        stream.once('finish', () => {
+          deferred.resolve()
+        })
 
-  //       body.pipe(stream)
-  //     })
-  //   }
-  // })
-  // .add('undici - stream', {
-  //   defer: true,
-  //   fn: deferred => {
-  //     pool.stream(undiciOptions, () => {
-  //       const stream = new Writable({
-  //         write (chunk, encoding, callback) {
-  //           callback()
-  //         }
-  //       })
-  //       stream.once('finish', () => {
-  //         deferred.resolve()
-  //       })
+        body.pipe(stream)
+      })
+    }
+  })
+  .add('undici - stream', {
+    defer: true,
+    fn: deferred => {
+      pool.stream(undiciOptions, () => {
+        const stream = new Writable({
+          write (chunk, encoding, callback) {
+            callback()
+          }
+        })
+        stream.once('finish', () => {
+          deferred.resolve()
+        })
 
-  //       return stream
-  //     }, error => {
-  //       if (error) {
-  //         throw error
-  //       }
-  //     })
-  //   }
-  // })
-  // .add('undici - dispatch', {
-  //   defer: true,
-  //   fn: deferred => {
-  //     const stream = new Writable({
-  //       write (chunk, encoding, callback) {
-  //         callback()
-  //       }
-  //     })
-  //     stream.once('finish', () => {
-  //       deferred.resolve()
-  //     })
-  //     pool.dispatch(undiciOptions, new SimpleRequest(stream))
-  //   }
-  // })
+        return stream
+      }, error => {
+        if (error) {
+          throw error
+        }
+      })
+    }
+  })
+  .add('undici - dispatch', {
+    defer: true,
+    fn: deferred => {
+      const stream = new Writable({
+        write (chunk, encoding, callback) {
+          callback()
+        }
+      })
+      stream.once('finish', () => {
+        deferred.resolve()
+      })
+      pool.dispatch(undiciOptions, new SimpleRequest(stream))
+    }
+  })
   .add('undici - noop', {
     defer: true,
     fn: deferred => {

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -42,97 +42,97 @@ const suite = new Benchmark.Suite()
 Benchmark.options.minSamples = 200
 
 suite
-  .add('http - keepalive', {
-    defer: true,
-    fn: deferred => {
-      http.get(httpOptions, response => {
-        const stream = new Writable({
-          write (chunk, encoding, callback) {
-            callback()
-          }
-        })
-        stream.once('finish', () => {
-          deferred.resolve()
-        })
+  // .add('http - keepalive', {
+  //   defer: true,
+  //   fn: deferred => {
+  //     http.get(httpOptions, response => {
+  //       const stream = new Writable({
+  //         write (chunk, encoding, callback) {
+  //           callback()
+  //         }
+  //       })
+  //       stream.once('finish', () => {
+  //         deferred.resolve()
+  //       })
 
-        response.pipe(stream)
-      })
-    }
-  })
-  .add('undici - pipeline', {
-    defer: true,
-    fn: deferred => {
-      pool
-        .pipeline(undiciOptions, data => {
-          return data.body
-        })
-        .end()
-        .pipe(new Writable({
-          write (chunk, encoding, callback) {
-            callback()
-          }
-        }))
-        .once('finish', () => {
-          deferred.resolve()
-        })
-    }
-  })
-  .add('undici - request', {
-    defer: true,
-    fn: deferred => {
-      pool.request(undiciOptions, (error, { body }) => {
-        if (error) {
-          throw error
-        }
+  //       response.pipe(stream)
+  //     })
+  //   }
+  // })
+  // .add('undici - pipeline', {
+  //   defer: true,
+  //   fn: deferred => {
+  //     pool
+  //       .pipeline(undiciOptions, data => {
+  //         return data.body
+  //       })
+  //       .end()
+  //       .pipe(new Writable({
+  //         write (chunk, encoding, callback) {
+  //           callback()
+  //         }
+  //       }))
+  //       .once('finish', () => {
+  //         deferred.resolve()
+  //       })
+  //   }
+  // })
+  // .add('undici - request', {
+  //   defer: true,
+  //   fn: deferred => {
+  //     pool.request(undiciOptions, (error, { body }) => {
+  //       if (error) {
+  //         throw error
+  //       }
 
-        const stream = new Writable({
-          write (chunk, encoding, callback) {
-            callback()
-          }
-        })
-        stream.once('finish', () => {
-          deferred.resolve()
-        })
+  //       const stream = new Writable({
+  //         write (chunk, encoding, callback) {
+  //           callback()
+  //         }
+  //       })
+  //       stream.once('finish', () => {
+  //         deferred.resolve()
+  //       })
 
-        body.pipe(stream)
-      })
-    }
-  })
-  .add('undici - stream', {
-    defer: true,
-    fn: deferred => {
-      pool.stream(undiciOptions, () => {
-        const stream = new Writable({
-          write (chunk, encoding, callback) {
-            callback()
-          }
-        })
-        stream.once('finish', () => {
-          deferred.resolve()
-        })
+  //       body.pipe(stream)
+  //     })
+  //   }
+  // })
+  // .add('undici - stream', {
+  //   defer: true,
+  //   fn: deferred => {
+  //     pool.stream(undiciOptions, () => {
+  //       const stream = new Writable({
+  //         write (chunk, encoding, callback) {
+  //           callback()
+  //         }
+  //       })
+  //       stream.once('finish', () => {
+  //         deferred.resolve()
+  //       })
 
-        return stream
-      }, error => {
-        if (error) {
-          throw error
-        }
-      })
-    }
-  })
-  .add('undici - dispatch', {
-    defer: true,
-    fn: deferred => {
-      const stream = new Writable({
-        write (chunk, encoding, callback) {
-          callback()
-        }
-      })
-      stream.once('finish', () => {
-        deferred.resolve()
-      })
-      pool.dispatch(undiciOptions, new SimpleRequest(stream))
-    }
-  })
+  //       return stream
+  //     }, error => {
+  //       if (error) {
+  //         throw error
+  //       }
+  //     })
+  //   }
+  // })
+  // .add('undici - dispatch', {
+  //   defer: true,
+  //   fn: deferred => {
+  //     const stream = new Writable({
+  //       write (chunk, encoding, callback) {
+  //         callback()
+  //       }
+  //     })
+  //     stream.once('finish', () => {
+  //       deferred.resolve()
+  //     })
+  //     pool.dispatch(undiciOptions, new SimpleRequest(stream))
+  //   }
+  // })
   .add('undici - noop', {
     defer: true,
     fn: deferred => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -112,7 +112,7 @@ function FastSocket (socket) {
     const chunks = buffer
     buffer = []
     writevGeneric(handle, chunks, (err) => {
-      // socket._unrefTimer()
+      socket._unrefTimer()
       if (err) {
         socket.destroy(err)
       } else if (buffer.length) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -66,6 +66,39 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
+function FastSocket (socket) {
+  let buffer = []
+  let writing = false
+
+  function flush () {
+    writing = true
+    const chunks = buffer
+    buffer = []
+    socket._writev(chunks, (err) => {
+      if (err) {
+        socket.destroy(err)
+      } else if (buffer.length) {
+        flush()
+      } else {
+        writing = false
+      }
+    })
+  }
+
+  socket.write = chunk => {
+    buffer.push({ chunk, encoding: 'ascii' })
+    if (!writing) {
+      flush()
+    }
+  }
+
+  socket.end = () => {
+    socket.destroy(new Error('socket closed'))
+  }
+
+  return socket
+}
+
 class Client extends EventEmitter {
   constructor (url, {
     maxAbortedPayload,
@@ -733,7 +766,7 @@ function connect (client) {
       : net.connect(port || /* istanbul ignore next */ 80, hostname)
   }
 
-  client[kSocket] = socket
+  client[kSocket] = FastSocket(socket)
 
   const parser = new Parser(client, socket)
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -96,28 +96,15 @@ function writeGeneric (handle, data, callback) {
 function FastSocket (socket) {
   const handle = socket._handle
 
-  let buffer = ''
-  let writing = false
-
   function onwrite (status) {
     socket._unrefTimer()
     if (status < 0) {
       socket.destroy(new Error(status))
-    } else if (buffer.length) {
-      const data = buffer
-      buffer = ''
-      writeGeneric(handle, data, onwrite)
-    } else {
-      writing = false
     }
   }
 
   socket.write = chunk => {
-    buffer += chunk
-    if (!writing) {
-      writing = true
-      process.nextTick(onwrite, 0)
-    }
+    writeGeneric(handle, chunk, onwrite)
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,12 @@ const net = require('net')
 const tls = require('tls')
 // TODO: This is not really allowed by Node but it works for now.
 const { HTTPParser } = process.binding('http_parser') // eslint-disable-line
+const {
+  WriteWrap,
+  kBytesWritten,
+  kLastWriteWasAsync,
+  streamBaseState
+} = process.binding('stream_wrap') // eslint-disable-line
 const EventEmitter = require('events')
 const assert = require('assert')
 const util = require('./util')
@@ -66,6 +72,29 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
+function onWriteComplete (status) {
+  this.callback(status < 0 ? new Error(status) : null)
+}
+
+function writevGeneric (handle, chunks, callback) {
+  const req = new WriteWrap()
+
+  req.handle = handle
+  req.oncomplete = onWriteComplete
+  req.async = false
+  req.bytes = 0
+  req.buffer = null
+  req.callback = callback
+
+  const err = req.handle.writev(req, chunks, false)
+
+  if (err === 0) {
+    req._chunks = chunks
+  }
+
+  return req
+}
+
 function FastSocket (socket) {
   let buffer = []
   let writing = false
@@ -74,7 +103,8 @@ function FastSocket (socket) {
     writing = true
     const chunks = buffer
     buffer = []
-    socket._writev(chunks, (err) => {
+    writevGeneric(socket._handle, chunks, (err) => {
+      socket._unrefTimer()
       if (err) {
         socket.destroy(err)
       } else if (buffer.length) {
@@ -86,7 +116,7 @@ function FastSocket (socket) {
   }
 
   socket.write = chunk => {
-    buffer.push({ chunk, encoding: 'ascii' })
+    buffer.push(chunk, 'ascii')
     if (!writing) {
       flush()
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -82,7 +82,7 @@ function FastSocket (socket) {
     }
   }
 
-  socket.write = chunk => {
+  socket.write = (chunk) => {
     const req = new WriteWrap()
 
     req.handle = handle
@@ -91,7 +91,15 @@ function FastSocket (socket) {
     req.bytes = 0
     req.buffer = null
 
-    const status = handle.writeAsciiString(req, chunk)
+    let status
+    if (typeof chunk === 'string') {
+      status = handle.writeAsciiString(req, chunk)
+    } else {
+      status = handle.writeBuffer(req, chunk)
+      if (streamBaseState[kLastWriteWasAsync]) {
+        req.buffer = chunk
+      }
+    }
 
     req.bytes = streamBaseState[kBytesWritten]
     req.async = !!streamBaseState[kLastWriteWasAsync]
@@ -99,6 +107,8 @@ function FastSocket (socket) {
     if (status !== 0) {
       onwrite(status)
     }
+
+    return true
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -72,7 +72,7 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
-function writevGeneric (handle, chunks, callback) {
+function writeGeneric (handle, data, callback) {
   const req = new WriteWrap()
 
   req.handle = handle
@@ -81,11 +81,7 @@ function writevGeneric (handle, chunks, callback) {
   req.bytes = 0
   req.buffer = null
 
-  const status = handle.writev(req, chunks, false)
-
-  if (status === 0) {
-    req._chunks = chunks
-  }
+  const status = handle.writeLatin1String(req, data)
 
   req.bytes = streamBaseState[kBytesWritten]
   req.async = !!streamBaseState[kLastWriteWasAsync]
@@ -100,7 +96,7 @@ function writevGeneric (handle, chunks, callback) {
 function FastSocket (socket) {
   const handle = socket._handle
 
-  let buffer = []
+  let buffer = ''
   let writing = false
 
   function onwrite (status) {
@@ -108,19 +104,19 @@ function FastSocket (socket) {
     if (status < 0) {
       socket.destroy(new Error(status))
     } else if (buffer.length) {
-      writing = true
-      const chunks = buffer
-      buffer = []
-      writevGeneric(handle, chunks, onwrite)
+      const data = buffer
+      buffer = ''
+      writeGeneric(handle, data, onwrite)
     } else {
       writing = false
     }
   }
 
   socket.write = chunk => {
-    buffer.push(chunk, 'ascii')
+    buffer += chunk
     if (!writing) {
-      onwrite(0)
+      writing = true
+      process.nextTick(onwrite, 0)
     }
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -95,9 +95,12 @@ function writeGeneric (handle, chunk, callback) {
 
 function FastSocket (socket) {
   const handle = socket._handle
+  const onwrite = (err) => {
+    socket.destroy(err)
+  }
 
   socket.write = chunk => {
-    writeGeneric(handle, chunk)
+    writeGeneric(handle, chunk, onwrite)
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -72,7 +72,7 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
-function writeGeneric (handle, chunk, callback) {
+function writevGeneric (handle, chunks, callback) {
   const req = new WriteWrap()
 
   req.handle = handle
@@ -81,7 +81,11 @@ function writeGeneric (handle, chunk, callback) {
   req.bytes = 0
   req.buffer = null
 
-  const status = handle.writeAsciiString(req, chunk)
+  const status = handle.writev(req, chunks, false)
+
+  if (status === 0) {
+    req._chunks = chunks
+  }
 
   req.bytes = streamBaseState[kBytesWritten]
   req.async = !!streamBaseState[kLastWriteWasAsync]
@@ -95,12 +99,33 @@ function writeGeneric (handle, chunk, callback) {
 
 function FastSocket (socket) {
   const handle = socket._handle
-  const onwrite = (err) => {
-    socket.destroy(err)
+
+  let buffer = []
+  let writing = false
+
+  function onwrite (status) {
+    socket._unrefTimer()
+    if (status < 0) {
+      socket.destroy(new Error(status))
+    } else if (buffer.length) {
+      flush()
+    } else {
+      writing = false
+    }
+  }
+
+  function flush () {
+    writing = true
+    const chunks = buffer
+    buffer = []
+    writevGeneric(handle, chunks, onwrite)
   }
 
   socket.write = chunk => {
-    writeGeneric(handle, chunk, onwrite)
+    buffer.push(chunk, 'ascii')
+    if (!writing) {
+      flush()
+    }
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -73,24 +73,6 @@ const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
 function writeGeneric (handle, data, callback) {
-  const req = new WriteWrap()
-
-  req.handle = handle
-  req.oncomplete = callback
-  req.async = false
-  req.bytes = 0
-  req.buffer = null
-
-  const status = handle.writeLatin1String(req, data)
-
-  req.bytes = streamBaseState[kBytesWritten]
-  req.async = !!streamBaseState[kLastWriteWasAsync]
-
-  if (status !== 0) {
-    callback(status)
-  } else if (!req.async) {
-    callback()
-  }
 }
 
 function FastSocket (socket) {
@@ -104,7 +86,22 @@ function FastSocket (socket) {
   }
 
   socket.write = chunk => {
-    writeGeneric(handle, chunk, onwrite)
+    const req = new WriteWrap()
+
+    req.handle = handle
+    req.oncomplete = onwrite
+    req.async = false
+    req.bytes = 0
+    req.buffer = null
+
+    const status = handle.writeLatin1String(req, chunk)
+
+    req.bytes = streamBaseState[kBytesWritten]
+    req.async = !!streamBaseState[kLastWriteWasAsync]
+
+    if (status !== 0) {
+      onwrite(status)
+    }
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -86,16 +86,24 @@ function writevGeneric (handle, chunks, callback) {
   req.buffer = null
   req.callback = callback
 
-  const err = req.handle.writev(req, chunks, false)
+  const err = handle.writev(req, chunks, false)
 
-  if (err === 0) {
-    req._chunks = chunks
+  // Retain chunks
+  if (err === 0) req._chunks = chunks
+
+  req.bytes = streamBaseState[kBytesWritten]
+  req.async = !!streamBaseState[kLastWriteWasAsync]
+
+  if (err !== 0) {
+    callback(new Error(err))
+  } else if (!req.async) {
+    callback()
   }
-
-  return req
 }
 
 function FastSocket (socket) {
+  const handle = socket._handle
+
   let buffer = []
   let writing = false
 
@@ -103,8 +111,8 @@ function FastSocket (socket) {
     writing = true
     const chunks = buffer
     buffer = []
-    writevGeneric(socket._handle, chunks, (err) => {
-      socket._unrefTimer()
+    writevGeneric(handle, chunks, (err) => {
+      // socket._unrefTimer()
       if (err) {
         socket.destroy(err)
       } else if (buffer.length) {
@@ -123,7 +131,7 @@ function FastSocket (socket) {
   }
 
   socket.end = () => {
-    // socket.destroy(new Error('socket closed'))
+    socket.destroy(new SocketError('other side closed'))
   }
 
   return socket

--- a/lib/client.js
+++ b/lib/client.js
@@ -108,23 +108,19 @@ function FastSocket (socket) {
     if (status < 0) {
       socket.destroy(new Error(status))
     } else if (buffer.length) {
-      flush()
+      writing = true
+      const chunks = buffer
+      buffer = []
+      writevGeneric(handle, chunks, onwrite)
     } else {
       writing = false
     }
   }
 
-  function flush () {
-    writing = true
-    const chunks = buffer
-    buffer = []
-    writevGeneric(handle, chunks, onwrite)
-  }
-
   socket.write = chunk => {
     buffer.push(chunk, 'ascii')
     if (!writing) {
-      flush()
+      onwrite(0)
     }
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -66,6 +66,7 @@ const makeRequest = require('./client-request').request
 const makePipeline = require('./client-pipeline').pipeline
 const makeUpgrade = require('./client-upgrade').upgrade
 const makeConnect = require('./client-connect').connect
+const fs = require('fs')
 
 const CRLF = Buffer.from('\r\n', 'ascii')
 
@@ -75,38 +76,15 @@ const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 function FastSocket (socket) {
   const handle = socket._handle
 
-  function onwrite (status) {
+  function onwrite (err) {
     socket._unrefTimer()
-    if (status < 0) {
-      socket.destroy(new Error(status))
+    if (err) {
+      socket.destroy(err)
     }
   }
 
   socket.write = (chunk) => {
-    const req = new WriteWrap()
-
-    req.handle = handle
-    req.oncomplete = onwrite
-    req.async = false
-    req.bytes = 0
-    req.buffer = null
-
-    let status
-    if (typeof chunk === 'string') {
-      status = handle.writeAsciiString(req, chunk)
-    } else {
-      status = handle.writeBuffer(req, chunk)
-      if (streamBaseState[kLastWriteWasAsync]) {
-        req.buffer = chunk
-      }
-    }
-
-    req.bytes = streamBaseState[kBytesWritten]
-    req.async = !!streamBaseState[kLastWriteWasAsync]
-
-    if (status !== 0) {
-      onwrite(status)
-    }
+    fs.write(handle.fd, chunk, onwrite)
 
     return true
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -91,7 +91,7 @@ function FastSocket (socket) {
     req.bytes = 0
     req.buffer = null
 
-    const status = handle.writeLatin1String(req, chunk)
+    const status = handle.writeAsciiString(req, chunk)
 
     req.bytes = streamBaseState[kBytesWritten]
     req.async = !!streamBaseState[kLastWriteWasAsync]

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,7 +123,7 @@ function FastSocket (socket) {
   }
 
   socket.end = () => {
-    socket.destroy(new Error('socket closed'))
+    // socket.destroy(new Error('socket closed'))
   }
 
   return socket

--- a/lib/client.js
+++ b/lib/client.js
@@ -72,7 +72,7 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
-function writevGeneric (handle, chunks, callback) {
+function writeGeneric (handle, chunk, callback) {
   const req = new WriteWrap()
 
   req.handle = handle
@@ -81,11 +81,7 @@ function writevGeneric (handle, chunks, callback) {
   req.bytes = 0
   req.buffer = null
 
-  const status = handle.writev(req, chunks, false)
-
-  if (status === 0) {
-    req._chunks = chunks
-  }
+  const status = handle.writeAsciiString(req, chunk)
 
   req.bytes = streamBaseState[kBytesWritten]
   req.async = !!streamBaseState[kLastWriteWasAsync]
@@ -100,30 +96,8 @@ function writevGeneric (handle, chunks, callback) {
 function FastSocket (socket) {
   const handle = socket._handle
 
-  let buffer = []
-  let writing = false
-
-  function flush () {
-    writing = true
-    const chunks = buffer
-    buffer = []
-    writevGeneric(handle, chunks, (status) => {
-      socket._unrefTimer()
-      if (status < 0) {
-        socket.destroy(new Error(status))
-      } else if (buffer.length) {
-        flush()
-      } else {
-        writing = false
-      }
-    })
-  }
-
   socket.write = chunk => {
-    buffer.push(chunk, 'ascii')
-    if (!writing) {
-      flush()
-    }
+    writeGeneric(handle, chunk)
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -72,30 +72,26 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
-function onWriteComplete (status) {
-  this.callback(status < 0 ? new Error(status) : null)
-}
-
 function writevGeneric (handle, chunks, callback) {
   const req = new WriteWrap()
 
   req.handle = handle
-  req.oncomplete = onWriteComplete
+  req.oncomplete = callback
   req.async = false
   req.bytes = 0
   req.buffer = null
-  req.callback = callback
 
-  const err = handle.writev(req, chunks, false)
+  const status = handle.writev(req, chunks, false)
 
-  // Retain chunks
-  if (err === 0) req._chunks = chunks
+  if (status === 0) {
+    req._chunks = chunks
+  }
 
   req.bytes = streamBaseState[kBytesWritten]
   req.async = !!streamBaseState[kLastWriteWasAsync]
 
-  if (err !== 0) {
-    callback(new Error(err))
+  if (status !== 0) {
+    callback(status)
   } else if (!req.async) {
     callback()
   }
@@ -111,10 +107,10 @@ function FastSocket (socket) {
     writing = true
     const chunks = buffer
     buffer = []
-    writevGeneric(handle, chunks, (err) => {
+    writevGeneric(handle, chunks, (status) => {
       socket._unrefTimer()
-      if (err) {
-        socket.destroy(err)
+      if (status < 0) {
+        socket.destroy(new Error(status))
       } else if (buffer.length) {
         flush()
       } else {
@@ -128,7 +124,6 @@ function FastSocket (socket) {
     if (!writing) {
       flush()
     }
-    return true
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -128,6 +128,7 @@ function FastSocket (socket) {
     if (!writing) {
       flush()
     }
+    return true
   }
 
   socket.end = () => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -72,9 +72,6 @@ const CRLF = Buffer.from('\r\n', 'ascii')
 const nodeMajorVersion = parseInt(process.version.split('.')[0].slice(1))
 const insecureHTTPParser = process.execArgv.includes('--insecure-http-parser')
 
-function writeGeneric (handle, data, callback) {
-}
-
 function FastSocket (socket) {
   const handle = socket._handle
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -289,6 +289,7 @@ class Request {
       resume()
     }
 
+    console.error(err)
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {
       handler.onError(err)

--- a/lib/request.js
+++ b/lib/request.js
@@ -289,7 +289,6 @@ class Request {
       resume()
     }
 
-    console.error(err)
     // TODO: Try to avoid nextTick here.
     process.nextTick((handler, err) => {
       handler.onError(err)


### PR DESCRIPTION
This is mostly a crazy experiment to see what perf gains can be achieved by bypassing `Writable`. If anyone wants to play around with profiling and experimenting with this.

Interestingly enough there doesn't seem to be much performance to gain here.

```js
http - keepalive x 5,795 ops/sec ±1.78% (275 runs sampled)
undici - pipeline x 8,520 ops/sec ±1.48% (274 runs sampled)
undici - request x 12,594 ops/sec ±0.63% (277 runs sampled)
undici - stream x 13,935 ops/sec ±0.58% (279 runs sampled)
undici - dispatch x 14,553 ops/sec ±0.76% (276 runs sampled)
undici - noop x 22,110 ops/sec ±1.09% (257 runs sampled)
```

```js
http - keepalive x 5,757 ops/sec ±1.54% (275 runs sampled)
undici - pipeline x 8,751 ops/sec ±1.51% (276 runs sampled)
undici - request x 12,279 ops/sec ±0.53% (280 runs sampled)
undici - stream x 13,631 ops/sec ±0.48% (280 runs sampled)
undici - dispatch x 14,388 ops/sec ±0.40% (279 runs sampled)
undici - noop x 20,883 ops/sec ±0.69% (265 runs sampled)
```