### PR TITLE
Revert "fix: prepend client url pathname (#313)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ A basic HTTP/1.1 client, mapped on top a single TCP/TLS connection.
 Keepalive is enabled by default, and it cannot be turned off.
 
 `url` can be a string or a [`URL`](https://nodejs.org/api/url.html#url_class_url) object.
-It should only include the pathname, protocol, hostname, and the port. If `pathname` is
-provided it will always be joined with any request path.
+It should only include the protocol, hostname, and the port.
 
 Options:
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,15 +102,11 @@ class Client extends EventEmitter {
       throw new InvalidArgumentError('invalid hostname')
     }
 
-    if (url.pathname != null && (typeof url.pathname !== 'string' || url.pathname[0] !== '/')) {
-      throw new InvalidArgumentError('invalid pathname')
-    }
-
     if (!/https?/.test(url.protocol)) {
       throw new InvalidArgumentError('invalid protocol')
     }
 
-    if (url.search || url.hash) {
+    if (/\/.+/.test(url.pathname) || url.search || url.hash) {
       throw new InvalidArgumentError('invalid url')
     }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,7 +29,7 @@ class Request {
     requestTimeout
   }, {
     [kRequestTimeout]: defaultRequestTimeout,
-    [kUrl]: { hostname, pathname }
+    [kUrl]: { hostname }
   }, handler) {
     if (typeof path !== 'string' || path[0] !== '/') {
       throw new InvalidArgumentError('path must be a valid path')
@@ -45,10 +45,6 @@ class Request {
 
     if (signal && typeof signal.on !== 'function' && typeof signal.addEventListener !== 'function') {
       throw new InvalidArgumentError('signal must be an EventEmitter or EventTarget')
-    }
-
-    if (pathname && pathname.length > 1) {
-      path = pathname.replace(/\/$/, '') + path
     }
 
     requestTimeout = requestTimeout == null && defaultRequestTimeout

--- a/test/client-errors.js
+++ b/test/client-errors.js
@@ -251,6 +251,13 @@ test('invalid options throws', (t) => {
   }
 
   try {
+    new Client(new URL('http://asd:200/somepath')) // eslint-disable-line
+  } catch (err) {
+    t.ok(err instanceof errors.InvalidArgumentError)
+    t.strictEqual(err.message, 'invalid url')
+  }
+
+  try {
     new Client(new URL('http://asd:200?q=asd')) // eslint-disable-line
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
@@ -361,15 +368,6 @@ test('invalid options throws', (t) => {
   } catch (err) {
     t.ok(err instanceof errors.InvalidArgumentError)
     t.strictEqual(err.message, 'invalid hostname')
-  }
-
-  try {
-    new Client({ // eslint-disable-line
-      pathname: ''
-    })
-  } catch (err) {
-    t.ok(err instanceof errors.InvalidArgumentError)
-    t.strictEqual(err.message, 'invalid pathname')
   }
 
   try {

--- a/test/client.js
+++ b/test/client.js
@@ -12,7 +12,7 @@ test('basic get', (t) => {
   t.plan(20)
 
   const server = createServer((req, res) => {
-    t.strictEqual('/asd/', req.url)
+    t.strictEqual('/', req.url)
     t.strictEqual('GET', req.method)
     t.strictEqual('localhost', req.headers.host)
     t.strictEqual(undefined, req.headers.foo)
@@ -29,7 +29,7 @@ test('basic get', (t) => {
   }
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}/asd`)
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.tearDown(client.close.bind(client))
 
     client.request({
@@ -72,7 +72,7 @@ test('basic head', (t) => {
   t.plan(14)
 
   const server = createServer((req, res) => {
-    t.strictEqual('/asd/123', req.url)
+    t.strictEqual('/123', req.url)
     t.strictEqual('HEAD', req.method)
     t.strictEqual('localhost', req.headers.host)
     res.setHeader('content-type', 'text/plain')
@@ -81,7 +81,7 @@ test('basic head', (t) => {
   t.tearDown(server.close.bind(server))
 
   server.listen(0, () => {
-    const client = new Client(`http://localhost:${server.address().port}/asd/`)
+    const client = new Client(`http://localhost:${server.address().port}`)
     t.tearDown(client.close.bind(client))
 
     client.request({ path: '/123', method: 'HEAD' }, (err, { statusCode, headers, body }) => {


### PR DESCRIPTION
This reverts commit 911d724e1bd6b1872b83d9555daa70c07fb20362.

Not part of any release yet. This added some ambiguity in behavior as well as added unnecessary complexity. Something I would like to avoid as much as possible. This logic should probably live in higher level abstraction.