### PR TITLE
fix: close() deadlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,16 +431,18 @@ Options:
 
 The `handler` parameter is defined as follow:
 
+* `onConnect(abort)`, invoked before request is dispatched on socket.
+  * `abort(): Void`, abort request.
 * `onUpgrade(statusCode, headers, socket): Void`, invoked when request is upgraded  either due to a `Upgrade` header or `CONNECT` method.
   * `statusCode: Number`
   * `headers: Array|Null`
   * `socket: Duplex`
-* `onHeaders(statusCode, headers, resume): Void`, invoked when statusCode and headers have been received. 
+* `onHeaders(statusCode, headers, resume): Void`, invoked when statusCode and headers have been received.
   May be invoked multiple times due to 1xx informational headers.
   * `statusCode: Number`
   * `headers: Array|Null`, an array of key-value pairs. Keys are not automatically lowercased.
   * `resume(): Void`, resume `onData` after returning `false`.
-* `onData(chunk): Null|Boolean`, invoked when response payload data is received.
+* `onData(chunk): Boolean`, invoked when response payload data is received.
   * `chunk: Buffer`
 * `onComplete(trailers): Void`, invoked when response payload and trailers have been received and the request has completed.
   * `trailers: Array|Null`

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -149,7 +149,11 @@ class NoopRequest {
     this.deferred = deferred
   }
 
-  onHeaders () {
+  onConnect (abort) {
+
+  }
+
+  onHeaders (statusCode, headers, resume) {
 
   }
 
@@ -165,6 +169,9 @@ class NoopRequest {
 class SimpleRequest {
   constructor (dst) {
     this.dst = dst
+  }
+
+  onConnect (abort) {
   }
 
   onHeaders (statusCode, headers, resume) {

--- a/lib/client-connect.js
+++ b/lib/client-connect.js
@@ -18,6 +18,9 @@ class ConnectHandler extends AsyncResource {
     this.callback = callback
   }
 
+  onConnect (abort) {
+  }
+
   onUpgrade (statusCode, headers, socket) {
     const { callback, opaque } = this
 

--- a/lib/client-pipeline.js
+++ b/lib/client-pipeline.js
@@ -45,12 +45,15 @@ class PipelineRequest extends Readable {
 
 class PipelineResponse extends Readable {
   constructor (resume) {
-    super({ autoDestroy: true, read: resume })
+    super({ autoDestroy: true })
+    this[kResume] = resume
+  }
+
+  _read () {
+    this[kResume]()
   }
 
   _destroy (err, callback) {
-    this._read()
-
     if (!err && !this._readableState.endEmitted) {
       err = new RequestAbortedError()
     }
@@ -77,6 +80,7 @@ class PipelineHandler extends AsyncResource {
 
     this.opaque = opts.opaque || null
     this.handler = handler
+    this.abort = null
 
     this.req = new PipelineRequest()
 
@@ -100,10 +104,14 @@ class PipelineHandler extends AsyncResource {
         }
       },
       destroy: (err, callback) => {
-        const { body, req, res, ret } = this
+        const { body, req, res, ret, abort } = this
 
         if (!err && !ret._readableState.endEmitted) {
           err = new RequestAbortedError()
+        }
+
+        if (abort && err) {
+          abort()
         }
 
         util.destroy(body, err)
@@ -120,6 +128,15 @@ class PipelineHandler extends AsyncResource {
     })
 
     this.res = null
+  }
+
+  onConnect (abort) {
+    const { ret } = this
+    if (ret.destroyed) {
+      abort()
+    } else {
+      this.abort = abort
+    }
   }
 
   onHeaders (statusCode, headers, resume) {
@@ -180,29 +197,17 @@ class PipelineHandler extends AsyncResource {
 
   onData (chunk) {
     const { res } = this
-
-    if (res._readableState.destroyed) {
-      return
-    }
-
     return res.push(chunk)
   }
 
   onComplete (trailers) {
     const { res } = this
-
-    if (res._readableState.destroyed) {
-      return
-    }
-
     res.push(null)
   }
 
   onError (err) {
     const { ret } = this
-
     this.handler = null
-
     util.destroy(ret, err)
   }
 }

--- a/lib/client-request.js
+++ b/lib/client-request.js
@@ -8,16 +8,21 @@ const {
 const util = require('./util')
 const { AsyncResource } = require('async_hooks')
 
+const kAbort = Symbol('abort')
+
 class RequestResponse extends Readable {
-  constructor (resume) {
+  constructor (resume, abort) {
     super({ autoDestroy: true, read: resume })
+    this[kAbort] = abort
   }
 
   _destroy (err, callback) {
-    this._read()
-
     if (!err && !this._readableState.endEmitted) {
       err = new RequestAbortedError()
+    }
+
+    if (err) {
+      this[kAbort]()
     }
 
     callback(err)
@@ -39,16 +44,21 @@ class RequestHandler extends AsyncResource {
     this.opaque = opts.opaque || null
     this.callback = callback
     this.res = null
+    this.abort = null
+  }
+
+  onConnect (abort) {
+    this.abort = abort
   }
 
   onHeaders (statusCode, headers, resume) {
-    const { callback, opaque } = this
+    const { callback, opaque, abort } = this
 
     if (statusCode < 200) {
       return
     }
 
-    const body = new RequestResponse(resume)
+    const body = new RequestResponse(resume, abort)
 
     this.callback = null
     this.res = body
@@ -63,21 +73,11 @@ class RequestHandler extends AsyncResource {
 
   onData (chunk) {
     const { res } = this
-
-    if (res._readableState.destroyed) {
-      return
-    }
-
     return res.push(chunk)
   }
 
   onComplete (trailers) {
     const { res } = this
-
-    if (res._readableState.destroyed) {
-      return
-    }
-
     res.push(null)
   }
 

--- a/lib/client-stream.js
+++ b/lib/client-stream.js
@@ -28,7 +28,12 @@ class StreamHandler extends AsyncResource {
     this.factory = factory
     this.callback = callback
     this.res = null
+    this.abort = null
     this.trailers = null
+  }
+
+  onConnect (abort) {
+    this.abort = abort
   }
 
   onHeaders (statusCode, headers, resume) {
@@ -57,11 +62,15 @@ class StreamHandler extends AsyncResource {
     res.on('drain', resume)
     // TODO: Avoid finished. It registers an unecessary amount of listeners.
     finished(res, { readable: false }, (err) => {
-      const { callback, res, opaque, trailers } = this
+      const { callback, res, opaque, trailers, abort } = this
 
       this.res = null
       if (err || !res.readable) {
         util.destroy(res, err)
+      }
+
+      if (err) {
+        abort()
       }
 
       this.callback = null
@@ -73,23 +82,12 @@ class StreamHandler extends AsyncResource {
 
   onData (chunk) {
     const { res } = this
-
-    if (util.isDestroyed(res)) {
-      return
-    }
-
     return res.write(chunk)
   }
 
   onComplete (trailers) {
     const { res } = this
-
-    if (util.isDestroyed(res)) {
-      return
-    }
-
     this.trailers = trailers ? util.parseHeaders(trailers) : {}
-
     res.end()
   }
 
@@ -101,7 +99,7 @@ class StreamHandler extends AsyncResource {
     if (res) {
       this.res = null
       util.destroy(res, err)
-    } else {
+    } else if (callback) {
       this.callback = null
       this.runInAsyncScope(callback, null, err, { opaque })
     }

--- a/lib/client-upgrade.js
+++ b/lib/client-upgrade.js
@@ -18,6 +18,9 @@ class UpgradeHandler extends AsyncResource {
     this.callback = callback
   }
 
+  onConnect (abort) {
+  }
+
   onUpgrade (statusCode, headers, socket) {
     const { callback, opaque } = this
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -166,6 +166,9 @@ class Client extends EventEmitter {
     this[kResuming] = 0 // 0, idle, 1, scheduled, 2 resuming
     this[kDrained] = false
     this[kMaxAbortedPayload] = maxAbortedPayload || 1048576
+    this[kResume] = () => {
+      resume(this)
+    }
 
     // kQueue is built up of 3 sections separated by
     // the kRunningIdx and kPendingIdx indices.
@@ -932,11 +935,10 @@ function _resume (client) {
       return
     }
 
-    try {
-      write(client, request)
+    if (write(client, request)) {
       client[kPendingIdx]++
-    } catch (err) {
-      request.onError(err)
+    } else {
+      client[kQueue].splice(client[kPendingIdx], 1)
     }
   }
 }
@@ -965,7 +967,11 @@ function write (client, request) {
   }
 
   if (request.contentLength !== null && request.contentLength !== contentLength) {
-    throw new ContentLengthMismatchError()
+    request.onError(new ContentLengthMismatchError())
+  }
+
+  if (!request.onConnect(client[kSocket])) {
+    return false
   }
 
   // TODO: Expect: 100-continue
@@ -1114,6 +1120,8 @@ function write (client, request) {
 
     client[kWriting] = true
   }
+
+  return true
 }
 
 module.exports = Client

--- a/lib/request.js
+++ b/lib/request.js
@@ -8,11 +8,15 @@ const {
 } = require('./errors')
 const net = require('net')
 const util = require('./util')
-const { kRequestTimeout, kUrl } = require('./symbols')
+const {
+  kRequestTimeout,
+  kUrl,
+  kSocket,
+  kResume
+} = require('./symbols')
 
 const kAbort = Symbol('abort')
 const kTimeout = Symbol('timeout')
-const kResume = Symbol('resume')
 const kSignal = Symbol('signal')
 const kHandler = Symbol('handler')
 
@@ -28,7 +32,8 @@ class Request {
     requestTimeout
   }, {
     [kRequestTimeout]: defaultRequestTimeout,
-    [kUrl]: { hostname, protocol }
+    [kUrl]: { hostname, protocol },
+    [kResume]: resume
   }, handler) {
     if (typeof path !== 'string' || path[0] !== '/') {
       throw new InvalidArgumentError('path must be a valid path')
@@ -187,7 +192,8 @@ class Request {
       }, requestTimeout, this)
       : null
 
-    this[kResume] = null
+    this[kResume] = resume
+    this[kSocket] = null
   }
 
   get expectsPayload () {
@@ -232,6 +238,26 @@ class Request {
     return false
   }
 
+  onConnect (socket) {
+    if (this.aborted) {
+      return false
+    }
+
+    this[kSocket] = socket
+
+    try {
+      this[kHandler].onConnect(() => {
+        if (this[kResume]) {
+          this.onError(new RequestAbortedError())
+        }
+      })
+    } catch (err) {
+      this.onError(err)
+    }
+
+    return !this.aborted
+  }
+
   onUpgrade (statusCode, headers, socket) {
     if (this.aborted) {
       util.destroy(socket, new RequestAbortedError())
@@ -252,8 +278,6 @@ class Request {
     if (this.aborted) {
       return
     }
-
-    this[kResume] = resume
 
     const {
       [kTimeout]: timeout
@@ -288,6 +312,9 @@ class Request {
       return
     }
 
+    this[kResume] = null
+    this[kSocket] = null
+
     reset.call(this)
 
     try {
@@ -305,13 +332,19 @@ class Request {
 
     reset.call(this, err)
 
-    const { [kResume]: resume } = this
+    const {
+      [kResume]: resume,
+      [kSocket]: socket
+    } = this
 
-    // TODO: resume is probably only needed
-    // when aborted through signal or body?
     if (resume) {
       this[kResume] = null
       resume()
+    }
+
+    if (socket) {
+      this[kSocket] = null
+      socket.resume()
     }
 
     // TODO: Try to avoid nextTick here.

--- a/test/client-dispatch.js
+++ b/test/client-dispatch.js
@@ -49,6 +49,8 @@ test('basic dispatch get', (t) => {
       method: 'GET',
       headers: reqHeaders
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         t.strictEqual(statusCode, 200)
         t.strictEqual(Array.isArray(headers), true)
@@ -99,6 +101,8 @@ test('trailers dispatch get', (t) => {
       method: 'GET',
       headers: reqHeaders
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         t.strictEqual(statusCode, 200)
         t.strictEqual(Array.isArray(headers), true)
@@ -142,6 +146,8 @@ test('dispatch onHeaders error', (t) => {
       path: '/',
       method: 'GET'
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         throw _err
       },
@@ -175,6 +181,8 @@ test('dispatch onComplete error', (t) => {
       path: '/',
       method: 'GET'
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         t.pass()
       },
@@ -208,6 +216,8 @@ test('dispatch onData error', (t) => {
       path: '/',
       method: 'GET'
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         t.pass()
       },

--- a/test/pool.js
+++ b/test/pool.js
@@ -414,6 +414,8 @@ test('pool dispatch', (t) => {
       path: '/',
       method: 'GET'
     }, {
+      onConnect () {
+      },
       onHeaders (statusCode, headers) {
         t.strictEqual(statusCode, 200)
       },


### PR DESCRIPTION
When no resume is going to be scheduled, request.onError might never be detected or in the case of `Client.pipeline` the stream destroy.

See test case in first commit, https://github.com/mcollina/undici/pull/345/commits/adb4faee1f7a1dc545ea2373f39d49f30c4455e9.

Fixes: https://github.com/mcollina/undici/issues/344

----

There is a problem with the existing API where if a running request is aborted while the server is not providing any data nothing is ticking the state machine.

There are some API changes:

- A new hook is added on dispatch handler, `onConnect(abort)`. 

- `onData` now only returns a boolean (no magical `null`).
